### PR TITLE
particles: Improve RNG, reduce number of particles

### DIFF
--- a/src/sample/particles/main.ts
+++ b/src/sample/particles/main.ts
@@ -4,7 +4,7 @@ import { makeSample, SampleInit } from '../../components/SampleLayout';
 import particleWGSL from './particle.wgsl';
 import probabilityMapWGSL from './probabilityMap.wgsl';
 
-const numParticles = 1000000;
+const numParticles = 50000;
 const particlePositionOffset = 0;
 const particleColorOffset = 4 * 4;
 const particleInstanceByteSize =


### PR DESCRIPTION
The RNG was poorly seeded, resulting in multiple particles having exactly the same simulation values. This affected blending and performance.

By fixing the RNG seed, we can spawn 20x fewer particles and have it look nicer than it did.