### PR TITLE
Use VideoFrame constructor

### DIFF
--- a/src/sample/videoUploadingWebCodecs/main.ts
+++ b/src/sample/videoUploadingWebCodecs/main.ts
@@ -61,35 +61,11 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     minFilter: 'linear',
   });
 
-  function getVideoFrameFromVideoElement(video) {
-    return new Promise((resolve) => {
-      const videoTrack = video.captureStream().getVideoTracks()[0];
-      const trackProcessor = new MediaStreamTrackProcessor({
-        track: videoTrack,
-      });
-      const transformer = new TransformStream({
-        transform(videoFrame) {
-          videoTrack.stop();
-          resolve(videoFrame);
-        },
-        flush(controller) {
-          controller.terminate();
-        },
-      });
-      const trackGenerator = new MediaStreamTrackGenerator({
-        kind: 'video',
-      });
-      trackProcessor.readable
-        .pipeThrough(transformer)
-        .pipeTo(trackGenerator.writable);
-    });
-  }
-
-  async function frame() {
+  function frame() {
     // Sample is no longer the active page.
     if (!pageState.active) return;
 
-    const videoFrame = await getVideoFrameFromVideoElement(video);
+    const videoFrame = new VideoFrame(video);
 
     const uniformBindGroup = device.createBindGroup({
       layout: pipeline.getBindGroupLayout(0),


### PR DESCRIPTION
Following up https://github.com/webgpu/webgpu-samples/pull/247#discussion_r1169126377, this PR uses `new VideoFrame()` instead of `MediaStreamTrackProcessor` to get a video frame from a video HTML element.

@kainino0x @shaoboyan Please review.