### PR TITLE
cornell: Fix 'raytracer' dispatch

### DIFF
--- a/src/sample/cornell/raytracer.ts
+++ b/src/sample/cornell/raytracer.ts
@@ -105,8 +105,8 @@ export default class Raytracer {
     passEncoder.setBindGroup(0, this.common.uniforms.bindGroup);
     passEncoder.setBindGroup(1, this.bindGroup);
     passEncoder.dispatchWorkgroups(
-      this.framebuffer.width / this.kWorkgroupSizeX,
-      this.framebuffer.height / this.kWorkgroupSizeY
+      Math.ceil(this.framebuffer.width / this.kWorkgroupSizeX),
+      Math.ceil(this.framebuffer.height / this.kWorkgroupSizeY)
     );
     passEncoder.end();
   }


### PR DESCRIPTION
This was rounding down the number of workgroups instead of 'ceil', resulting in a border at the right / bottom with garbage data.