### PR TITLE
Create ImageBitmaps from fetch instead of img.src

### DIFF
--- a/src/sample/cubemap/main.ts
+++ b/src/sample/cubemap/main.ts
@@ -132,10 +132,9 @@ const init: SampleInit = async ({ canvas, pageState }) => {
         import.meta.url
       ).toString(),
     ];
-    const promises = imgSrcs.map((src) => {
-      const img = document.createElement('img');
-      img.src = src;
-      return img.decode().then(() => createImageBitmap(img));
+    const promises = imgSrcs.map(async (src) => {
+      const response = await fetch(src);
+      return createImageBitmap(await response.blob());
     });
     const imageBitmaps = await Promise.all(promises);
 

--- a/src/sample/imageBlur/main.ts
+++ b/src/sample/imageBlur/main.ts
@@ -64,13 +64,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     minFilter: 'linear',
   });
 
-  const img = document.createElement('img');
-  img.src = new URL(
-    '../../../assets/img/Di-3d.png',
-    import.meta.url
-  ).toString();
-  await img.decode();
-  const imageBitmap = await createImageBitmap(img);
+  const response = await fetch(
+    new URL('../../../assets/img/Di-3d.png', import.meta.url).toString()
+  );
+  const imageBitmap = await createImageBitmap(await response.blob());
 
   const [srcWidth, srcHeight] = [imageBitmap.width, imageBitmap.height];
   const cubeTexture = device.createTexture({

--- a/src/sample/particles/main.ts
+++ b/src/sample/particles/main.ts
@@ -185,13 +185,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   let textureHeight = 1;
   let numMipLevels = 1;
   {
-    const img = document.createElement('img');
-    img.src = new URL(
-      '../../../assets/img/webgpu.png',
-      import.meta.url
-    ).toString();
-    await img.decode();
-    const imageBitmap = await createImageBitmap(img);
+    const response = await fetch(
+      new URL('../../../assets/img/webgpu.png', import.meta.url).toString()
+    );
+    const imageBitmap = await createImageBitmap(await response.blob());
 
     // Calculate number of mip levels required to generate the probability map
     while (

--- a/src/sample/renderBundles/main.ts
+++ b/src/sample/renderBundles/main.ts
@@ -118,13 +118,10 @@ const init: SampleInit = async ({ canvas, pageState, gui, stats }) => {
   // Fetch the images and upload them into a GPUTexture.
   let planetTexture: GPUTexture;
   {
-    const img = document.createElement('img');
-    img.src = new URL(
-      '../../../assets/img/saturn.jpg',
-      import.meta.url
-    ).toString();
-    await img.decode();
-    const imageBitmap = await createImageBitmap(img);
+    const response = await fetch(
+      new URL('../../../assets/img/saturn.jpg', import.meta.url).toString()
+    );
+    const imageBitmap = await createImageBitmap(await response.blob());
 
     planetTexture = device.createTexture({
       size: [imageBitmap.width, imageBitmap.height, 1],
@@ -143,13 +140,10 @@ const init: SampleInit = async ({ canvas, pageState, gui, stats }) => {
 
   let moonTexture: GPUTexture;
   {
-    const img = document.createElement('img');
-    img.src = new URL(
-      '../../../assets/img/moon.jpg',
-      import.meta.url
-    ).toString();
-    await img.decode();
-    const imageBitmap = await createImageBitmap(img);
+    const response = await fetch(
+      new URL('../../../assets/img/moon.jpg', import.meta.url).toString()
+    );
+    const imageBitmap = await createImageBitmap(await response.blob());
 
     moonTexture = device.createTexture({
       size: [imageBitmap.width, imageBitmap.height, 1],

--- a/src/sample/texturedCube/main.ts
+++ b/src/sample/texturedCube/main.ts
@@ -110,13 +110,10 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   // Fetch the image and upload it into a GPUTexture.
   let cubeTexture: GPUTexture;
   {
-    const img = document.createElement('img');
-    img.src = new URL(
-      '../../../assets/img/Di-3d.png',
-      import.meta.url
-    ).toString();
-    await img.decode();
-    const imageBitmap = await createImageBitmap(img);
+    const response = await fetch(
+      new URL('../../../assets/img/Di-3d.png', import.meta.url).toString()
+    );
+    const imageBitmap = await createImageBitmap(await response.blob());
 
     cubeTexture = device.createTexture({
       size: [imageBitmap.width, imageBitmap.height, 1],


### PR DESCRIPTION
createImageBitmap from fetch() is a best practice:

- HTMLImageElement isn't portable to Workers (helpful for anyone who wants to copy examples from here into their application).
- Creating an HTMLImageElement provides an incorrect signal to the browser that you want to put it in the DOM.
- img.decode() waits for the image to be ready to display in the DOM; it won't necessarily guarantee that there will be no synchronous blocking decode of the image in order to make the ImageBitmap.