### PR TITLE
Use wgpu-matrix 2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/dom-mediacapture-transform": "^0.1.5",
-        "@types/stats.js": "^0.17.0",
         "codemirror": "^5.58.2",
         "dat.gui": "^0.7.6",
         "file-loader": "^6.2.0",
@@ -19,7 +18,7 @@
         "react-dom": "^18.2.0",
         "stanford-dragon": "^1.1.1",
         "stats-js": "^1.0.1",
-        "wgpu-matrix": "^1.1.0"
+        "wgpu-matrix": "^2.4.0"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^13.0.0",
@@ -28,6 +27,7 @@
         "@types/node": "^18.11.8",
         "@types/react": "^18.0.24",
         "@types/react-dom": "^18.0.8",
+        "@types/stats.js": "^0.17.0",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
         "@typescript-eslint/parser": "^5.41.0",
         "@webgpu/types": "^0.1.21",
@@ -561,7 +561,8 @@
     "node_modules/@types/stats.js": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.0.tgz",
-      "integrity": "sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w=="
+      "integrity": "sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==",
+      "dev": true
     },
     "node_modules/@types/tern": {
       "version": "0.23.3",
@@ -3971,9 +3972,9 @@
       }
     },
     "node_modules/wgpu-matrix": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/wgpu-matrix/-/wgpu-matrix-1.1.0.tgz",
-      "integrity": "sha512-lKXD2A3+z+hTZdmOP1F8eFeux5wttuc9NtTU50XPCd/ThkMDoPSOgAqTrYQg6L0kkeyndrp+4SW5KkUIc7f0GQ=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/wgpu-matrix/-/wgpu-matrix-2.4.0.tgz",
+      "integrity": "sha512-/KUCdbOWWWiIwTqc4dLPKSsq0wLJhC9tCC3uARDFR6/ZZrf1KtDR9unEsu61oSe/SUymQv7sheQ9+xgVUx0byg=="
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^18.2.0",
     "stanford-dragon": "^1.1.1",
     "stats-js": "^1.0.1",
-    "wgpu-matrix": "^1.1.0"
+    "wgpu-matrix": "^2.4.0"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.0.0",

--- a/src/sample/cornell/common.ts
+++ b/src/sample/cornell/common.ts
@@ -101,7 +101,6 @@ export default class Common {
       vec3.fromValues(0, 5, 0),
       vec3.fromValues(0, 1, 0)
     );
-    mat4.inverse(viewMatrix, viewMatrix);
     const mvp = mat4.multiply(projectionMatrix, viewMatrix);
     const invMVP = mat4.invert(mvp);
 

--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -493,7 +493,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     2000.0
   );
 
-  const viewMatrix = mat4.inverse(mat4.lookAt(eyePosition, origin, upVector));
+  const viewMatrix = mat4.lookAt(eyePosition, origin, upVector);
 
   const viewProjMatrix = mat4.multiply(projectionMatrix, viewMatrix);
 
@@ -535,7 +535,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     const rotation = mat4.rotateY(mat4.translation(origin), rad);
     vec3.transformMat4(eyePosition, rotation, eyePosition);
 
-    const viewMatrix = mat4.inverse(mat4.lookAt(eyePosition, origin, upVector));
+    const viewMatrix = mat4.lookAt(eyePosition, origin, upVector);
 
     mat4.multiply(projectionMatrix, viewMatrix, viewProjMatrix);
     return viewProjMatrix as Float32Array;

--- a/src/sample/renderBundles/main.ts
+++ b/src/sample/renderBundles/main.ts
@@ -239,8 +239,7 @@ const init: SampleInit = async ({ canvas, pageState, gui, stats }) => {
     return bindGroup;
   }
 
-  const transform = mat4.create();
-  mat4.identity(transform);
+  const transform = mat4.identity() as Float32Array;
 
   // Create one large central planet surrounded by a large ring of asteroids
   const planet = createSphereRenderable(1.0);

--- a/src/sample/samplerParameters/main.ts
+++ b/src/sample/samplerParameters/main.ts
@@ -280,7 +280,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   const viewProj = mat4.translate(
     mat4.perspective(2 * Math.atan(1 / kCameraDist), 1, 0.1, 100),
     [0, 0, -kCameraDist]
-  );
+  ) as Float32Array;
   device.queue.writeBuffer(bufConfig, 0, viewProj);
 
   const bufMatrices = device.createBuffer({

--- a/src/sample/shadowMapping/main.ts
+++ b/src/sample/shadowMapping/main.ts
@@ -289,12 +289,10 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     2000.0
   );
 
-  const viewMatrix = mat4.inverse(mat4.lookAt(eyePosition, origin, upVector));
+  const viewMatrix = mat4.lookAt(eyePosition, origin, upVector);
 
   const lightPosition = vec3.fromValues(50, 100, -100);
-  const lightViewMatrix = mat4.inverse(
-    mat4.lookAt(lightPosition, origin, upVector)
-  );
+  const lightViewMatrix = mat4.lookAt(lightPosition, origin, upVector);
 
   const lightProjectionMatrix = mat4.create();
   {
@@ -364,7 +362,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     const rotation = mat4.rotateY(mat4.translation(origin), rad);
     vec3.transformMat4(eyePosition, rotation, eyePosition);
 
-    const viewMatrix = mat4.inverse(mat4.lookAt(eyePosition, origin, upVector));
+    const viewMatrix = mat4.lookAt(eyePosition, origin, upVector);
 
     mat4.multiply(projectionMatrix, viewMatrix, viewProjMatrix);
     return viewProjMatrix as Float32Array;


### PR DESCRIPTION
The breaking change was in 1.x, `mat4.lookAt` returned a camera matrix which was unexpected by most devs. 2.x changed `mat4.lookAt` to return a view matrix so that devs would get what they expect coming from other math libraries.

Closes #269
Fixes #268