### PR TITLE
fixing path to workload simulator

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -94,7 +94,7 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
             <h3>Other Pages</h3>
             <ul className={styles.exampleList}>
               <li>
-                <a target="_blank" href="workload-simulator.html">
+                <a target="_blank" href="/workload-simulator.html">
                   Workload Simulator ↗️
                 </a>
               </li>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -94,7 +94,13 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
             <h3>Other Pages</h3>
             <ul className={styles.exampleList}>
               <li>
-                <a target="_blank" href={`${process.env.BASE_PATH || ''}/workload-simulator.html`>
+                <a
+                  rel="noreferrer"
+                  target="_blank"
+                  href={`${
+                    process.env.BASE_PATH || ''
+                  }/workload-simulator.html`}
+                >
                   Workload Simulator ↗️
                 </a>
               </li>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -94,7 +94,7 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
             <h3>Other Pages</h3>
             <ul className={styles.exampleList}>
               <li>
-                <a target="_blank" href="/workload-simulator.html">
+                <a target="_blank" href={`${process.env.BASE_PATH || ''}/workload-simulator.html`>
                   Workload Simulator ↗️
                 </a>
               </li>


### PR DESCRIPTION
Simple fix for the link to "Workload Simulator" in the "Other Pages" section. This link currently opens the workload simulator relative to the context at the time of clicking it, producing an incorrect path and a 404.

To reproduce:
- Visit any of the samples first, then open the workload simulator. It will open under https://webgpu.github.io/webgpu-samples/samples/workload-simulator.html (note: removing `/samples` from the url fixes the 404)
- Click the "WebGPU Samples" header in the sidebar first, then open the workload simulator. It will open under https://webgpu.github.io/workload-simulator.html (notice `/webgpu-samples` is missing from the path)

Adding a `/` to the beginning of the `href` value so the Workload Simulator loads from an absolute path, where https://webgpu.github.io/webgpu-samples/ is the root.