### PR TITLE
Enhance A-buffer sample with ability to split into multiple passes to limit memory usage

### DIFF
--- a/src/sample/a-buffer/composite.wgsl
+++ b/src/sample/a-buffer/composite.wgsl
@@ -4,6 +4,10 @@ struct Uniforms {
   targetWidth: u32,
 };
 
+struct SliceInfo {
+  sliceStartY: i32
+};
+
 struct Heads {
   numFragments: u32,
   data: array<u32>
@@ -22,6 +26,7 @@ struct LinkedList {
 @binding(0) @group(0) var<uniform> uniforms: Uniforms;
 @binding(1) @group(0) var<storage, read_write> heads: Heads;
 @binding(2) @group(0) var<storage, read_write> linkedList: LinkedList;
+@binding(3) @group(0) var<uniform> sliceInfo: SliceInfo;
 
 // Output a full screen quad
 @vertex
@@ -41,7 +46,7 @@ fn main_vs(@builtin(vertex_index) vertIndex: u32) -> @builtin(position) vec4<f32
 @fragment
 fn main_fs(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
   let fragCoords = vec2<i32>(position.xy);
-  let headsIndex = u32(fragCoords.y) * uniforms.targetWidth + u32(fragCoords.x);
+  let headsIndex = u32(fragCoords.y - sliceInfo.sliceStartY) * uniforms.targetWidth + u32(fragCoords.x);
 
   // The maximum layers we can process for any pixel
   const maxLayers = 24u;

--- a/src/sample/a-buffer/main.ts
+++ b/src/sample/a-buffer/main.ts
@@ -347,7 +347,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     //    the limit. The tradeoff here is that the canvas resolution will not
     //    match the native resolution and therefore may have a reduction in
     //    quality.
-    // 2) Break the frame into a series of vertical slices using the scissor
+    // 2) Break the frame into a series of horizontal slices using the scissor
     //    functionality and process a single slice at a time. This limits memory
     //    usage because we only need enough memory to process the dimensions
     //    of the slice. The tradeoff is the performance reduction due to multiple

--- a/src/sample/a-buffer/main.ts
+++ b/src/sample/a-buffer/main.ts
@@ -573,6 +573,13 @@ const init: SampleInit = async ({ canvas, pageState }) => {
         headsInitBuffer.size
       );
 
+      const scissorX = 0;
+      const scissorY = slice * sliceHeight;
+      const scissorWidth = canvas.width;
+      const scissorHeight =
+        Math.min((slice + 1) * sliceHeight, canvas.height) -
+        slice * sliceHeight;
+
       // Draw the translucent objects
       translucentPassDescriptor.colorAttachments[0].view = textureView;
       const translucentPassEncoder = commandEncoder.beginRenderPass(
@@ -581,10 +588,10 @@ const init: SampleInit = async ({ canvas, pageState }) => {
 
       // Set the scissor to only process a horizontal slice of the frame
       translucentPassEncoder.setScissorRect(
-        0,
-        slice * sliceHeight,
-        canvas.width,
-        Math.min((slice + 1) * sliceHeight, canvas.height) - slice * sliceHeight
+        scissorX,
+        scissorY,
+        scissorWidth,
+        scissorHeight
       );
 
       translucentPassEncoder.setPipeline(translucentPipeline);
@@ -604,10 +611,10 @@ const init: SampleInit = async ({ canvas, pageState }) => {
 
       // Set the scissor to only process a horizontal slice of the frame
       compositePassEncoder.setScissorRect(
-        0,
-        slice * sliceHeight,
-        canvas.width,
-        Math.min((slice + 1) * sliceHeight, canvas.height) - slice * sliceHeight
+        scissorX,
+        scissorY,
+        scissorWidth,
+        scissorHeight
       );
 
       compositePassEncoder.setPipeline(compositePipeline);

--- a/src/sample/a-buffer/main.ts
+++ b/src/sample/a-buffer/main.ts
@@ -17,39 +17,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
 
   if (!pageState.active) return;
 
-  const params = new URLSearchParams(window.location.search);
-
-  const settings = {
-    bufferSizeLimitMitigation:
-      params.get('bufferSizeLimitMitigation') || 'multipass',
-  };
-
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
-
-  let devicePixelRatio = window.devicePixelRatio || 1;
-
-  // The default maximum storage buffer binding size is 128Mib. The amount
-  // of memory we need to store transparent fragments depends on the size
-  // of the canvas and the average number of layers per fragment we want to
-  // support. When the devicePixelRatio is 1, we know that 128Mib is enough
-  // to store 4 layers per pixel. However, when the device pixel ratio is
-  // high enough (such as on some mobile devices) we will exceed this limit.
-  // We provide 2 mitigations to this issue:
-  // 1) Clamp the device pixel ratio to a value which we know will not break
-  //    the limit. The tradeoff here is that the canvas resolution will not
-  //    match the native resolution and therefore may have a reduction in
-  //    quality.
-  // 2) Break the frame into a series of vertical slices using the scissor
-  //    functionality and process a single slice at a time. This limits memory
-  //    usage because we only need enough memory to process the dimensions
-  //    of the slice. The tradeoff is the performance reduction due to multiple
-  //    passes.
-  if (settings.bufferSizeLimitMitigation == 'clamp pixel ratio') {
-    devicePixelRatio = Math.min(window.devicePixelRatio, 3);
-  }
-
-  canvas.width = canvas.clientWidth * devicePixelRatio;
-  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
@@ -58,16 +26,11 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     alphaMode: 'premultiplied',
   });
 
-  const depthTexture = device.createTexture({
-    size: [canvas.width, canvas.height],
-    format: 'depth24plus',
-    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
-    label: 'depthTexture',
-  });
+  const params = new URLSearchParams(window.location.search);
 
-  const depthTextureView = depthTexture.createView({
-    label: 'depthTextureView',
-  });
+  const settings = {
+    memoryStrategy: params.get('memoryStrategy') || 'multipass',
+  };
 
   // Create the model vertex buffer
   const vertexBuffer = device.createBuffer({
@@ -98,94 +61,6 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
       mapping.set(mesh.triangles[i], 3 * i);
     }
     indexBuffer.unmap();
-  }
-
-  // Determines how much memory is allocated to store linked-list elements
-  const averageLayersPerFragment = 4;
-
-  // Each element stores
-  // * color : vec4<f32>
-  // * depth : f32
-  // * index of next element in the list : u32
-  const linkedListElementSize =
-    5 * Float32Array.BYTES_PER_ELEMENT + 1 * Uint32Array.BYTES_PER_ELEMENT;
-
-  let numSlices = 1;
-  let sliceHeight = canvas.height;
-
-  // We want to keep the linked-list buffer size under the maxStorageBufferBindingSize.
-  // First calculate the size needed to process the entire frame at once, and then
-  // if necessary break it up into horizontal slices until it's under the limit.
-  const calculateLinkedListBufferSize = (width: number, height: number) => {
-    return averageLayersPerFragment * linkedListElementSize * width * height;
-  };
-
-  let linkedListBufferSize = calculateLinkedListBufferSize(
-    canvas.width,
-    canvas.height
-  );
-
-  while (linkedListBufferSize > device.limits.maxStorageBufferBindingSize) {
-    numSlices += 1;
-    sliceHeight = Math.ceil(canvas.height / numSlices);
-
-    linkedListBufferSize = calculateLinkedListBufferSize(
-      canvas.width,
-      sliceHeight
-    );
-  }
-
-  const linkedListBuffer = device.createBuffer({
-    size: linkedListBufferSize,
-    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    label: 'linkedListBuffer',
-  });
-
-  // To slice up the frame we need to pass the starting fragment y position of the slice.
-  // We do this using a uniform buffer with a dynamic offset.
-  const sliceInfoBuffer = device.createBuffer({
-    size: numSlices * device.limits.minUniformBufferOffsetAlignment,
-    usage: GPUBufferUsage.UNIFORM,
-    mappedAtCreation: true,
-    label: 'sliceInfoBuffer',
-  });
-  {
-    const mapping = new Int32Array(sliceInfoBuffer.getMappedRange());
-
-    // This assumes minUniformBufferOffsetAlignment is a multiple of 4
-    const stride =
-      device.limits.minUniformBufferOffsetAlignment /
-      Int32Array.BYTES_PER_ELEMENT;
-    for (let i = 0; i < numSlices; ++i) {
-      mapping[i * stride] = i * sliceHeight;
-    }
-    sliceInfoBuffer.unmap();
-  }
-
-  // `Heads` struct contains the start index of the linked-list of translucent fragments
-  // for a given pixel.
-  // * numFragments : u32
-  // * data : array<u32>
-  const headsBuffer = device.createBuffer({
-    size: (1 + canvas.width * sliceHeight) * Uint32Array.BYTES_PER_ELEMENT,
-    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    label: 'headsBuffer',
-  });
-
-  const headsInitBuffer = device.createBuffer({
-    size: (1 + canvas.width * sliceHeight) * Uint32Array.BYTES_PER_ELEMENT,
-    usage: GPUBufferUsage.COPY_SRC,
-    mappedAtCreation: true,
-    label: 'headsInitBuffer',
-  });
-  {
-    const buffer = new Uint32Array(headsInitBuffer.getMappedRange());
-
-    for (let i = 0; i < buffer.length; ++i) {
-      buffer[i] = 0xffffffff;
-    }
-
-    headsInitBuffer.unmap();
   }
 
   // Uniforms contains:
@@ -242,7 +117,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     depthStencil: {
       depthWriteEnabled: true,
       depthCompare: 'less',
-      format: depthTexture.format,
+      format: 'depth24plus',
     },
     label: 'opaquePipeline',
   });
@@ -257,7 +132,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
       },
     ],
     depthStencilAttachment: {
-      view: depthTextureView,
+      view: undefined,
       depthClearValue: 1.0,
       depthLoadOp: 'clear',
       depthStoreOp: 'store',
@@ -373,46 +248,6 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     label: 'translucentPassDescriptor',
   };
 
-  const translucentBindGroup = device.createBindGroup({
-    layout: translucentBindGroupLayout,
-    entries: [
-      {
-        binding: 0,
-        resource: {
-          buffer: uniformBuffer,
-          label: 'uniforms',
-        },
-      },
-      {
-        binding: 1,
-        resource: {
-          buffer: headsBuffer,
-          label: 'headsBuffer',
-        },
-      },
-      {
-        binding: 2,
-        resource: {
-          buffer: linkedListBuffer,
-          label: 'linkedListBuffer',
-        },
-      },
-      {
-        binding: 3,
-        resource: depthTextureView,
-      },
-      {
-        binding: 4,
-        resource: {
-          buffer: sliceInfoBuffer,
-          size: device.limits.minUniformBufferOffsetAlignment,
-          label: 'sliceInfoBuffer',
-        },
-      },
-    ],
-    label: 'translucentBindGroup',
-  });
-
   const compositeModule = device.createShaderModule({
     code: compositeWGSL,
     label: 'compositeModule',
@@ -496,166 +331,345 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     label: 'compositePassDescriptor',
   };
 
-  const compositeBindGroup = device.createBindGroup({
-    layout: compositePipeline.getBindGroupLayout(0),
-    entries: [
-      {
-        binding: 0,
-        resource: {
-          buffer: uniformBuffer,
-          label: 'uniforms',
-        },
-      },
-      {
-        binding: 1,
-        resource: {
-          buffer: headsBuffer,
-          label: 'headsBuffer',
-        },
-      },
-      {
-        binding: 2,
-        resource: {
-          buffer: linkedListBuffer,
-          label: 'linkedListBuffer',
-        },
-      },
-      {
-        binding: 3,
-        resource: {
-          buffer: sliceInfoBuffer,
-          size: device.limits.minUniformBufferOffsetAlignment,
-          label: 'sliceInfoBuffer',
-        },
-      },
-    ],
-  });
+  const configure = () => {
+    let devicePixelRatio = window.devicePixelRatio || 1;
 
-  // Rotates the camera around the origin based on time.
-  function getCameraViewProjMatrix() {
-    const aspect = canvas.width / canvas.height;
+    // The default maximum storage buffer binding size is 128Mib. The amount
+    // of memory we need to store transparent fragments depends on the size
+    // of the canvas and the average number of layers per fragment we want to
+    // support. When the devicePixelRatio is 1, we know that 128Mib is enough
+    // to store 4 layers per pixel at 600x600. However, when the device pixel
+    // ratio is high enough (such as on some mobile devices) we will exceed
+    // this limit.
+    //
+    // We provide 2 choices of mitigations to this issue:
+    // 1) Clamp the device pixel ratio to a value which we know will not break
+    //    the limit. The tradeoff here is that the canvas resolution will not
+    //    match the native resolution and therefore may have a reduction in
+    //    quality.
+    // 2) Break the frame into a series of vertical slices using the scissor
+    //    functionality and process a single slice at a time. This limits memory
+    //    usage because we only need enough memory to process the dimensions
+    //    of the slice. The tradeoff is the performance reduction due to multiple
+    //    passes.
+    if (settings.memoryStrategy === 'clamp-pixel-ratio') {
+      devicePixelRatio = Math.min(window.devicePixelRatio, 3);
+    }
 
-    const projectionMatrix = mat4.perspective(
-      (2 * Math.PI) / 5,
-      aspect,
-      1,
-      2000.0
+    canvas.width = canvas.clientWidth * devicePixelRatio;
+    canvas.height = canvas.clientHeight * devicePixelRatio;
+
+    const depthTexture = device.createTexture({
+      size: [canvas.width, canvas.height],
+      format: 'depth24plus',
+      usage:
+        GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+      label: 'depthTexture',
+    });
+
+    const depthTextureView = depthTexture.createView({
+      label: 'depthTextureView',
+    });
+
+    // Determines how much memory is allocated to store linked-list elements
+    const averageLayersPerFragment = 4;
+
+    // Each element stores
+    // * color : vec4<f32>
+    // * depth : f32
+    // * index of next element in the list : u32
+    const linkedListElementSize =
+      5 * Float32Array.BYTES_PER_ELEMENT + 1 * Uint32Array.BYTES_PER_ELEMENT;
+
+    let numSlices = 1;
+    let sliceHeight = canvas.height;
+
+    // We want to keep the linked-list buffer size under the maxStorageBufferBindingSize.
+    // First calculate the size needed to process the entire frame at once, and then
+    // if necessary break it up into horizontal slices until it's under the limit.
+    const calculateLinkedListBufferSize = (width: number, height: number) => {
+      return averageLayersPerFragment * linkedListElementSize * width * height;
+    };
+
+    let linkedListBufferSize = calculateLinkedListBufferSize(
+      canvas.width,
+      canvas.height
     );
 
-    const upVector = vec3.fromValues(0, 1, 0);
-    const origin = vec3.fromValues(0, 0, 0);
-    const eyePosition = vec3.fromValues(0, 5, -100);
+    while (linkedListBufferSize > device.limits.maxStorageBufferBindingSize) {
+      numSlices += 1;
+      sliceHeight = Math.ceil(canvas.height / numSlices);
 
-    const rad = Math.PI * (Date.now() / 5000);
-    const rotation = mat4.rotateY(mat4.translation(origin), rad);
-    vec3.transformMat4(eyePosition, rotation, eyePosition);
+      linkedListBufferSize = calculateLinkedListBufferSize(
+        canvas.width,
+        sliceHeight
+      );
+    }
 
-    const viewMatrix = mat4.lookAt(eyePosition, origin, upVector);
+    const linkedListBuffer = device.createBuffer({
+      size: linkedListBufferSize,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      label: 'linkedListBuffer',
+    });
 
-    const viewProjMatrix = mat4.multiply(projectionMatrix, viewMatrix);
-    return viewProjMatrix as Float32Array;
-  }
+    // To slice up the frame we need to pass the starting fragment y position of the slice.
+    // We do this using a uniform buffer with a dynamic offset.
+    const sliceInfoBuffer = device.createBuffer({
+      size: numSlices * device.limits.minUniformBufferOffsetAlignment,
+      usage: GPUBufferUsage.UNIFORM,
+      mappedAtCreation: true,
+      label: 'sliceInfoBuffer',
+    });
+    {
+      const mapping = new Int32Array(sliceInfoBuffer.getMappedRange());
 
-  gui.add(settings, 'bufferSizeLimitMitigation', [
-    'multipass',
-    'clamp pixel ratio',
-  ]);
+      // This assumes minUniformBufferOffsetAlignment is a multiple of 4
+      const stride =
+        device.limits.minUniformBufferOffsetAlignment /
+        Int32Array.BYTES_PER_ELEMENT;
+      for (let i = 0; i < numSlices; ++i) {
+        mapping[i * stride] = i * sliceHeight;
+      }
+      sliceInfoBuffer.unmap();
+    }
+
+    // `Heads` struct contains the start index of the linked-list of translucent fragments
+    // for a given pixel.
+    // * numFragments : u32
+    // * data : array<u32>
+    const headsBuffer = device.createBuffer({
+      size: (1 + canvas.width * sliceHeight) * Uint32Array.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      label: 'headsBuffer',
+    });
+
+    const headsInitBuffer = device.createBuffer({
+      size: (1 + canvas.width * sliceHeight) * Uint32Array.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+      label: 'headsInitBuffer',
+    });
+    {
+      const buffer = new Uint32Array(headsInitBuffer.getMappedRange());
+
+      for (let i = 0; i < buffer.length; ++i) {
+        buffer[i] = 0xffffffff;
+      }
+
+      headsInitBuffer.unmap();
+    }
+
+    const translucentBindGroup = device.createBindGroup({
+      layout: translucentBindGroupLayout,
+      entries: [
+        {
+          binding: 0,
+          resource: {
+            buffer: uniformBuffer,
+            label: 'uniforms',
+          },
+        },
+        {
+          binding: 1,
+          resource: {
+            buffer: headsBuffer,
+            label: 'headsBuffer',
+          },
+        },
+        {
+          binding: 2,
+          resource: {
+            buffer: linkedListBuffer,
+            label: 'linkedListBuffer',
+          },
+        },
+        {
+          binding: 3,
+          resource: depthTextureView,
+        },
+        {
+          binding: 4,
+          resource: {
+            buffer: sliceInfoBuffer,
+            size: device.limits.minUniformBufferOffsetAlignment,
+            label: 'sliceInfoBuffer',
+          },
+        },
+      ],
+      label: 'translucentBindGroup',
+    });
+
+    const compositeBindGroup = device.createBindGroup({
+      layout: compositePipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: {
+            buffer: uniformBuffer,
+            label: 'uniforms',
+          },
+        },
+        {
+          binding: 1,
+          resource: {
+            buffer: headsBuffer,
+            label: 'headsBuffer',
+          },
+        },
+        {
+          binding: 2,
+          resource: {
+            buffer: linkedListBuffer,
+            label: 'linkedListBuffer',
+          },
+        },
+        {
+          binding: 3,
+          resource: {
+            buffer: sliceInfoBuffer,
+            size: device.limits.minUniformBufferOffsetAlignment,
+            label: 'sliceInfoBuffer',
+          },
+        },
+      ],
+    });
+
+    opaquePassDescriptor.depthStencilAttachment.view = depthTextureView;
+
+    // Rotates the camera around the origin based on time.
+    function getCameraViewProjMatrix() {
+      const aspect = canvas.width / canvas.height;
+
+      const projectionMatrix = mat4.perspective(
+        (2 * Math.PI) / 5,
+        aspect,
+        1,
+        2000.0
+      );
+
+      const upVector = vec3.fromValues(0, 1, 0);
+      const origin = vec3.fromValues(0, 0, 0);
+      const eyePosition = vec3.fromValues(0, 5, -100);
+
+      const rad = Math.PI * (Date.now() / 5000);
+      const rotation = mat4.rotateY(mat4.translation(origin), rad);
+      vec3.transformMat4(eyePosition, rotation, eyePosition);
+
+      const viewMatrix = mat4.lookAt(eyePosition, origin, upVector);
+
+      const viewProjMatrix = mat4.multiply(projectionMatrix, viewMatrix);
+      return viewProjMatrix as Float32Array;
+    }
+
+    return function doDraw() {
+      // update the uniform buffer
+      {
+        const buffer = new ArrayBuffer(uniformBuffer.size);
+
+        new Float32Array(buffer).set(getCameraViewProjMatrix());
+        new Uint32Array(buffer, 16 * Float32Array.BYTES_PER_ELEMENT).set([
+          averageLayersPerFragment * canvas.width * sliceHeight,
+          canvas.width,
+        ]);
+
+        device.queue.writeBuffer(uniformBuffer, 0, buffer);
+      }
+
+      const commandEncoder = device.createCommandEncoder();
+      const textureView = context.getCurrentTexture().createView();
+
+      // Draw the opaque objects
+      opaquePassDescriptor.colorAttachments[0].view = textureView;
+      const opaquePassEncoder =
+        commandEncoder.beginRenderPass(opaquePassDescriptor);
+      opaquePassEncoder.setPipeline(opaquePipeline);
+      opaquePassEncoder.setBindGroup(0, opaqueBindGroup);
+      opaquePassEncoder.setVertexBuffer(0, vertexBuffer);
+      opaquePassEncoder.setIndexBuffer(indexBuffer, 'uint16');
+      opaquePassEncoder.drawIndexed(mesh.triangles.length * 3, 8);
+      opaquePassEncoder.end();
+
+      for (let slice = 0; slice < numSlices; ++slice) {
+        // initialize the heads buffer
+        commandEncoder.copyBufferToBuffer(
+          headsInitBuffer,
+          0,
+          headsBuffer,
+          0,
+          headsInitBuffer.size
+        );
+
+        const scissorX = 0;
+        const scissorY = slice * sliceHeight;
+        const scissorWidth = canvas.width;
+        const scissorHeight =
+          Math.min((slice + 1) * sliceHeight, canvas.height) -
+          slice * sliceHeight;
+
+        // Draw the translucent objects
+        translucentPassDescriptor.colorAttachments[0].view = textureView;
+        const translucentPassEncoder = commandEncoder.beginRenderPass(
+          translucentPassDescriptor
+        );
+
+        // Set the scissor to only process a horizontal slice of the frame
+        translucentPassEncoder.setScissorRect(
+          scissorX,
+          scissorY,
+          scissorWidth,
+          scissorHeight
+        );
+
+        translucentPassEncoder.setPipeline(translucentPipeline);
+        translucentPassEncoder.setBindGroup(0, translucentBindGroup, [
+          slice * device.limits.minUniformBufferOffsetAlignment,
+        ]);
+        translucentPassEncoder.setVertexBuffer(0, vertexBuffer);
+        translucentPassEncoder.setIndexBuffer(indexBuffer, 'uint16');
+        translucentPassEncoder.drawIndexed(mesh.triangles.length * 3, 8);
+        translucentPassEncoder.end();
+
+        // Composite the opaque and translucent objects
+        compositePassDescriptor.colorAttachments[0].view = textureView;
+        const compositePassEncoder = commandEncoder.beginRenderPass(
+          compositePassDescriptor
+        );
+
+        // Set the scissor to only process a horizontal slice of the frame
+        compositePassEncoder.setScissorRect(
+          scissorX,
+          scissorY,
+          scissorWidth,
+          scissorHeight
+        );
+
+        compositePassEncoder.setPipeline(compositePipeline);
+        compositePassEncoder.setBindGroup(0, compositeBindGroup, [
+          slice * device.limits.minUniformBufferOffsetAlignment,
+        ]);
+        compositePassEncoder.draw(6);
+        compositePassEncoder.end();
+      }
+
+      device.queue.submit([commandEncoder.finish()]);
+    };
+  };
+
+  let doDraw = configure();
+
+  const updateSettings = () => {
+    doDraw = configure();
+  };
+
+  gui
+    .add(settings, 'memoryStrategy', ['multipass', 'clamp-pixel-ratio'])
+    .onFinishChange(updateSettings);
 
   function frame() {
     // Sample is no longer the active page.
     if (!pageState.active) return;
 
-    // update the uniform buffer
-    {
-      const buffer = new ArrayBuffer(uniformBuffer.size);
-
-      new Float32Array(buffer).set(getCameraViewProjMatrix());
-      new Uint32Array(buffer, 16 * Float32Array.BYTES_PER_ELEMENT).set([
-        averageLayersPerFragment * canvas.width * sliceHeight,
-        canvas.width,
-      ]);
-
-      device.queue.writeBuffer(uniformBuffer, 0, buffer);
-    }
-
-    const commandEncoder = device.createCommandEncoder();
-
-    const textureView = context.getCurrentTexture().createView();
-
-    // Draw the opaque objects
-    opaquePassDescriptor.colorAttachments[0].view = textureView;
-    const opaquePassEncoder =
-      commandEncoder.beginRenderPass(opaquePassDescriptor);
-    opaquePassEncoder.setPipeline(opaquePipeline);
-    opaquePassEncoder.setBindGroup(0, opaqueBindGroup);
-    opaquePassEncoder.setVertexBuffer(0, vertexBuffer);
-    opaquePassEncoder.setIndexBuffer(indexBuffer, 'uint16');
-    opaquePassEncoder.drawIndexed(mesh.triangles.length * 3, 8);
-    opaquePassEncoder.end();
-
-    for (let slice = 0; slice < numSlices; ++slice) {
-      // initialize the heads buffer
-      commandEncoder.copyBufferToBuffer(
-        headsInitBuffer,
-        0,
-        headsBuffer,
-        0,
-        headsInitBuffer.size
-      );
-
-      const scissorX = 0;
-      const scissorY = slice * sliceHeight;
-      const scissorWidth = canvas.width;
-      const scissorHeight =
-        Math.min((slice + 1) * sliceHeight, canvas.height) -
-        slice * sliceHeight;
-
-      // Draw the translucent objects
-      translucentPassDescriptor.colorAttachments[0].view = textureView;
-      const translucentPassEncoder = commandEncoder.beginRenderPass(
-        translucentPassDescriptor
-      );
-
-      // Set the scissor to only process a horizontal slice of the frame
-      translucentPassEncoder.setScissorRect(
-        scissorX,
-        scissorY,
-        scissorWidth,
-        scissorHeight
-      );
-
-      translucentPassEncoder.setPipeline(translucentPipeline);
-      translucentPassEncoder.setBindGroup(0, translucentBindGroup, [
-        slice * device.limits.minUniformBufferOffsetAlignment,
-      ]);
-      translucentPassEncoder.setVertexBuffer(0, vertexBuffer);
-      translucentPassEncoder.setIndexBuffer(indexBuffer, 'uint16');
-      translucentPassEncoder.drawIndexed(mesh.triangles.length * 3, 8);
-      translucentPassEncoder.end();
-
-      // Composite the opaque and translucent objects
-      compositePassDescriptor.colorAttachments[0].view = textureView;
-      const compositePassEncoder = commandEncoder.beginRenderPass(
-        compositePassDescriptor
-      );
-
-      // Set the scissor to only process a horizontal slice of the frame
-      compositePassEncoder.setScissorRect(
-        scissorX,
-        scissorY,
-        scissorWidth,
-        scissorHeight
-      );
-
-      compositePassEncoder.setPipeline(compositePipeline);
-      compositePassEncoder.setBindGroup(0, compositeBindGroup, [
-        slice * device.limits.minUniformBufferOffsetAlignment,
-      ]);
-      compositePassEncoder.draw(6);
-      compositePassEncoder.end();
-    }
-
-    device.queue.submit([commandEncoder.finish()]);
+    doDraw();
 
     requestAnimationFrame(frame);
   }

--- a/src/sample/a-buffer/main.ts
+++ b/src/sample/a-buffer/main.ts
@@ -88,6 +88,9 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   let numSlices = 1;
   let sliceHeight = canvas.height;
 
+  // We want to keep the linked-list buffer size under the maxStorageBufferBindingSize.
+  // First calculate the size needed to process the entire frame at once, and then
+  // if necessary break it up into horizontal slices until it's under the limit.
   const calculateLinkedListBufferSize = (width: number, height: number) => {
     return averageLayersPerFragment * linkedListElementSize * width * height;
   };

--- a/src/sample/a-buffer/main.ts
+++ b/src/sample/a-buffer/main.ts
@@ -339,8 +339,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     // of the canvas and the average number of layers per fragment we want to
     // support. When the devicePixelRatio is 1, we know that 128Mib is enough
     // to store 4 layers per pixel at 600x600. However, when the device pixel
-    // ratio is high enough (such as on some mobile devices) we will exceed
-    // this limit.
+    // ratio is high enough we will exceed this limit.
     //
     // We provide 2 choices of mitigations to this issue:
     // 1) Clamp the device pixel ratio to a value which we know will not break

--- a/src/sample/a-buffer/main.ts
+++ b/src/sample/a-buffer/main.ts
@@ -297,13 +297,11 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     ],
   });
 
-  const translucentPipelineLayout = device.createPipelineLayout({
-    bindGroupLayouts: [translucentBindGroupLayout],
-    label: 'translucentPipelineLayout',
-  });
-
   const translucentPipeline = device.createRenderPipeline({
-    layout: translucentPipelineLayout,
+    layout: device.createPipelineLayout({
+      bindGroupLayouts: [translucentBindGroupLayout],
+      label: 'translucentPipelineLayout',
+    }),
     vertex: {
       module: translucentModule,
       entryPoint: 'main_vs',
@@ -427,13 +425,11 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     ],
   });
 
-  const compositePipelineLayout = device.createPipelineLayout({
-    bindGroupLayouts: [compositeBindGroupLayout],
-    label: 'compositePipelineLayout',
-  });
-
   const compositePipeline = device.createRenderPipeline({
-    layout: compositePipelineLayout,
+    layout: device.createPipelineLayout({
+      bindGroupLayouts: [compositeBindGroupLayout],
+      label: 'compositePipelineLayout',
+    }),
     vertex: {
       module: compositeModule,
       entryPoint: 'main_vs',

--- a/src/sample/a-buffer/translucent.wgsl
+++ b/src/sample/a-buffer/translucent.wgsl
@@ -4,6 +4,9 @@ struct Uniforms {
   targetWidth: u32,
 };
 
+struct SliceInfo {
+  sliceStartY: i32
+};
 
 struct Heads {
   numFragments: atomic<u32>,
@@ -24,6 +27,7 @@ struct LinkedList {
 @binding(1) @group(0) var<storage, read_write> heads: Heads;
 @binding(2) @group(0) var<storage, read_write> linkedList: LinkedList;
 @binding(3) @group(0) var opaqueDepthTexture: texture_depth_2d;
+@binding(4) @group(0) var<uniform> sliceInfo: SliceInfo;
 
 struct VertexOutput {
   @builtin(position) position: vec4<f32>,
@@ -72,7 +76,7 @@ fn main_fs(@builtin(position) position: vec4<f32>, @location(0) @interpolate(fla
 
   // The index in the heads buffer corresponding to the head data for the fragment at
   // the current location.
-  let headsIndex = u32(fragCoords.y) * uniforms.targetWidth + u32(fragCoords.x);
+  let headsIndex = u32(fragCoords.y - sliceInfo.sliceStartY) * uniforms.targetWidth + u32(fragCoords.x);
 
   // The index in the linkedList buffer at which to store the new fragment
   let fragIndex = atomicAdd(&heads.numFragments, 1u);


### PR DESCRIPTION
This is based on the discussion [here](https://github.com/webgpu/webgpu-samples/issues/294#issuecomment-1736252524). This also allows the user to select either multipass or devicePixelRatio clamping as the limiting strategy.