### PR TITLE
Fix any in bitonicSort example

### DIFF
--- a/src/sample/bitonicSort/utils.ts
+++ b/src/sample/bitonicSort/utils.ts
@@ -137,7 +137,10 @@ export const SampleInitFactoryWebGPU = async (
 
 export abstract class Base2DRendererClass {
   abstract switchBindGroup(name: string): void;
-  abstract startRun(commandEncoder: GPUCommandEncoder, ...args: any[]): void;
+  abstract startRun(
+    commandEncoder: GPUCommandEncoder,
+    ...args: unknown[]
+  ): void;
   renderPassDescriptor: GPURenderPassDescriptor;
   pipeline: GPURenderPipeline;
   bindGroupMap: Record<string, GPUBindGroup>;


### PR DESCRIPTION
This `any` is showing up in every lint run on every PR, even those not related to this sample.