### PR TITLE
Add timestamp query support to compute boids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/stats.js": "^0.17.0",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
         "@typescript-eslint/parser": "^5.41.0",
-        "@webgpu/types": "^0.1.21",
+        "@webgpu/types": "^0.1.38",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -1098,9 +1098,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.38.tgz",
+      "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
       "dev": true
     },
     "node_modules/@xtuc/ieee754": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/stats.js": "^0.17.0",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
-    "@webgpu/types": "^0.1.21",
+    "@webgpu/types": "^0.1.38",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/src/sample/computeBoids/main.ts
+++ b/src/sample/computeBoids/main.ts
@@ -318,9 +318,15 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
         // Periodically update the text for the timer stats
         const kNumTimerSamples = 100;
         if (t % kNumTimerSamples === 0) {
+          const avgComputeMicroseconds = Math.round(
+            computePassDurationSum / kNumTimerSamples / 1000
+          );
+          const avgRenderMicroseconds = Math.round(
+            renderPassDurationSum / kNumTimerSamples / 1000
+          );
           perfDisplay.textContent = `\
-avg compute pass duration: ${Math.round(computePassDurationSum / kNumTimerSamples / 1000)}µs
-avg render pass duration: ${Math.round(renderPassDurationSum / kNumTimerSamples / 1000)}µs
+avg compute pass duration: ${avgComputeMicroseconds}µs
+avg render pass duration: ${avgRenderMicroseconds}µs
 spare readback buffers: ${spareResultBuffers.length}`;
           computePassDurationSum = 0;
           renderPassDurationSum = 0;

--- a/src/sample/computeBoids/main.ts
+++ b/src/sample/computeBoids/main.ts
@@ -106,7 +106,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     },
   });
 
-  const renderPassDescriptor = {
+  const renderPassDescriptor: GPURenderPassDescriptor = {
     colorAttachments: [
       {
         view: undefined as GPUTextureView, // Assigned later
@@ -117,7 +117,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     ],
   };
 
-  const computePassDescriptor = {};
+  const computePassDescriptor: GPUComputePassDescriptor = {};
 
   let querySet: GPUQuerySet | undefined = undefined;
   if (hasTimestampQuery) {


### PR DESCRIPTION
This PR adds timestamp query support to the compute boids sample by showing render pass and compute pass durations. 

I've tried several approaches before this attempt:
- Creating a queryset each frame but it fails very quickly on macOS  with [DAWN_OUT_OF_MEMORY_ERROR](https://source.chromium.org/chromium/chromium/src/+/main:third_party/dawn/src/dawn/native/metal/QuerySetMTL.mm;l=71;drc=e542c349d58a443b323ac97843739c8264030df3).
- Waiting for `resultBuffer.mapAsync` to settle in `frame()` but this makes UI janky as expected.

![image](https://github.com/webgpu/webgpu-samples/assets/634478/6ae3d556-2443-4009-9d30-a114fcb131ed)
