### PR TITLE
Update perf display style

### DIFF
--- a/src/sample/computeBoids/main.ts
+++ b/src/sample/computeBoids/main.ts
@@ -14,13 +14,14 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
 
   const perfDisplayContainer = document.createElement('div');
   perfDisplayContainer.style.color = 'white';
-  perfDisplayContainer.style.background = 'black';
+  perfDisplayContainer.style.backdropFilter = 'blur(10px)';
   perfDisplayContainer.style.position = 'absolute';
-  perfDisplayContainer.style.top = '10px';
+  perfDisplayContainer.style.bottom = '10px';
   perfDisplayContainer.style.left = '10px';
   perfDisplayContainer.style.textAlign = 'left';
 
   const perfDisplay = document.createElement('pre');
+  perfDisplay.style.margin = '.5em';
   perfDisplayContainer.appendChild(perfDisplay);
   if (canvas.parentNode) {
     canvas.parentNode.appendChild(perfDisplayContainer);
@@ -335,8 +336,8 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
           );
           perfDisplay.textContent = `\
 avg compute pass duration: ${avgComputeMicroseconds}µs
-avg render pass duration: ${avgRenderMicroseconds}µs
-spare readback buffers: ${spareResultBuffers.length}`;
+avg render pass duration:  ${avgRenderMicroseconds}µs
+spare readback buffers:    ${spareResultBuffers.length}`;
           computePassDurationSum = 0;
           renderPassDurationSum = 0;
           timerSamples = 0;


### PR DESCRIPTION
This PR moves the perf display to the bottom left (instead of top left) so that controls can be accessed on mobile devices. It also updates style to make it look nicer (to my eyes at least).

**old vs. new**
<img src='https://github.com/webgpu/webgpu-samples/assets/634478/3dc970fc-0354-46f0-8a7c-32a0d67e06ce' width='49%'> <img src='https://github.com/webgpu/webgpu-samples/assets/634478/1b4627ed-02da-4d84-af48-328c4c74cd7b' width='49%'>
