### PR TITLE
Make GUI appear on top of other elements

### DIFF
--- a/src/components/SampleLayout.tsx
+++ b/src/components/SampleLayout.tsx
@@ -90,7 +90,11 @@ const SampleLayout: React.FunctionComponent<
     if (props.gui && process.browser) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const dat = require('dat.gui');
-      return new dat.GUI({ autoPlace: false });
+      const gui = new dat.GUI({ autoPlace: false });
+      // HACK: Make
+      gui.domElement.style.position = 'relative';
+      gui.domElement.style.zIndex = '1000';
+      return gui;
     }
     return undefined;
   }, []);


### PR DESCRIPTION
I was surprised to learn that this didn't default
to z-Index > 0. I think it works in most apps because it's expected not to call the GUI constructor until after your other elements have been created? (I didn't look too deeply)

It's possible you might want to move elements, see https://github.com/webgpu/webgpu-samples/pull/330

But in any case, it seemed like a good default.

Before:

<img src="https://github.com/webgpu/webgpu-samples/assets/234804/0593cfae-57f7-4893-9fe9-60c725d6eb30" width="320">
<img src="https://github.com/webgpu/webgpu-samples/assets/234804/c74ff84d-0be1-4e4a-aef1-5c9fcce119fc" width="320">






