### PR TITLE
Normalize vector in fragment shader

### DIFF
--- a/src/sample/deferredRendering/fragmentWriteGBuffers.wgsl
+++ b/src/sample/deferredRendering/fragmentWriteGBuffers.wgsl
@@ -15,7 +15,7 @@ fn main(
   let c = 0.2 + 0.5 * ((uv.x + uv.y) - 2.0 * floor((uv.x + uv.y) / 2.0));
 
   var output : GBufferOutput;
-  output.normal = vec4(fragNormal, 1.0);
+  output.normal = vec4(normalize(fragNormal), 1.0);
   output.albedo = vec4(c, c, c, 1.0);
 
   return output;

--- a/src/sample/shadowMapping/fragment.wgsl
+++ b/src/sample/shadowMapping/fragment.wgsl
@@ -37,7 +37,7 @@ fn main(input : FragmentInput) -> @location(0) vec4<f32> {
   }
   visibility /= 9.0;
 
-  let lambertFactor = max(dot(normalize(scene.lightPos - input.fragPos), input.fragNorm), 0.0);
+  let lambertFactor = max(dot(normalize(scene.lightPos - input.fragPos), normalize(input.fragNorm)), 0.0);
   let lightingFactor = min(ambientFactor + visibility * lambertFactor, 1.0);
 
   return vec4(lightingFactor * albedo, 1.0);


### PR DESCRIPTION
The normal vector passed to the fragment shader is the interpolated value between the vertex normals,
and it should be `normalize`d.

In the deferredRendering sample, the normal vector is written to the G-buffer and used in a later pass.
It looks like the texture sampled value are being used directly:
https://github.com/webgpu/webgpu-samples/blob/2d193cb2764c736f435ce748630fae5f29f7518d/src/sample/deferredRendering/fragmentDeferredRendering.wgsl#L55C7-L59