### PR TITLE
Simplified the compute boids example

### DIFF
--- a/src/sample/computeBoids/main.ts
+++ b/src/sample/computeBoids/main.ts
@@ -215,50 +215,6 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     initialParticleData[4 * i + 3] = 2 * (Math.random() - 0.5) * 0.1;
   }
 
-  // const particleBuffers: GPUBuffer[] = new Array(2);
-  // const particleBindGroups: GPUBindGroup[] = new Array(2);
-  // for (let i = 0; i < 2; ++i) {
-  //   particleBuffers[i] = device.createBuffer({
-  //     size: initialParticleData.byteLength,
-  //     usage: GPUBufferUsage.VERTEX | GPUBufferUsage.STORAGE,
-  //     mappedAtCreation: true,
-  //   });
-  //   new Float32Array(particleBuffers[i].getMappedRange()).set(
-  //     initialParticleData
-  //   );
-  //   particleBuffers[i].unmap();
-  // }
-  //
-  // for (let i = 0; i < 2; ++i) {
-  //   particleBindGroups[i] = device.createBindGroup({
-  //     layout: computePipeline.getBindGroupLayout(0),
-  //     entries: [
-  //       {
-  //         binding: 0,
-  //         resource: {
-  //           buffer: simParamBuffer,
-  //         },
-  //       },
-  //       {
-  //         binding: 1,
-  //         resource: {
-  //           buffer: particleBuffers[i],
-  //           offset: 0,
-  //           size: initialParticleData.byteLength,
-  //         },
-  //       },
-  //       {
-  //         binding: 2,
-  //         resource: {
-  //           buffer: particleBuffers[(i + 1) % 2],
-  //           offset: 0,
-  //           size: initialParticleData.byteLength,
-  //         },
-  //       },
-  //     ],
-  //   });
-  // }
-
   const particleBuffer: GPUBuffer = device.createBuffer({
     size: initialParticleData.byteLength,
     usage: GPUBufferUsage.VERTEX | GPUBufferUsage.STORAGE,

--- a/src/sample/computeBoids/updateSprites.wgsl
+++ b/src/sample/computeBoids/updateSprites.wgsl
@@ -11,20 +11,16 @@ struct SimParams {
   rule2Scale : f32,
   rule3Scale : f32,
 }
-struct Particles {
-  particles : array<Particle>,
-}
 @binding(0) @group(0) var<uniform> params : SimParams;
-@binding(1) @group(0) var<storage, read> particlesA : Particles;
-@binding(2) @group(0) var<storage, read_write> particlesB : Particles;
+@binding(1) @group(0) var<storage, read_write> particles : array<Particle>;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
   var index = GlobalInvocationID.x;
 
-  var vPos = particlesA.particles[index].pos;
-  var vVel = particlesA.particles[index].vel;
+  var vPos = particles[index].pos;
+  var vVel = particles[index].vel;
   var cMass = vec2(0.0);
   var cVel = vec2(0.0);
   var colVel = vec2(0.0);
@@ -33,13 +29,13 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
   var pos : vec2<f32>;
   var vel : vec2<f32>;
 
-  for (var i = 0u; i < arrayLength(&particlesA.particles); i++) {
+  for (var i = 0u; i < arrayLength(&particles); i++) {
     if (i == index) {
       continue;
     }
 
-    pos = particlesA.particles[i].pos.xy;
-    vel = particlesA.particles[i].vel.xy;
+    pos = particles[i].pos.xy;
+    vel = particles[i].vel.xy;
     if (distance(pos, vPos) < params.rule1Distance) {
       cMass += pos;
       cMassCount++;
@@ -78,6 +74,6 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
     vPos.y = -1.0;
   }
   // Write back
-  particlesB.particles[index].pos = vPos;
-  particlesB.particles[index].vel = vVel;
+  particles[index].pos = vPos;
+  particles[index].vel = vVel;
 }


### PR DESCRIPTION
This is a proposal to simplify the compute boids example by removing the buffers/bind groups ping pong.
Instead we just create one particle buffer and one bind group. Since the particle storage has a `read_write` access, there's no need to ping pong between two buffers.

I don't know why it was done like that in the first place but I suppose the storages access/capabilities might have changed since then?
Anyway I think that way it would be easier to understand and reproduce in another context.

Thanks for all the hard work by the way!