### PR TITLE
Fix redirect for videoUploadingWebCodecs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,15 +8,6 @@ module.exports = {
   basePath: BASE_PATH,
   compress: true,
   reactStrictMode: true,
-  async redirects() {
-    return [
-      {
-        source: `${BASE_PATH}/samples/videoUploadingWebCodecs`,
-        destination: `${BASE_PATH}/samples/videoUploading?videoSource=videoFrame`,
-        permanent: true,
-      },
-    ]
-  },
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     config.module.rules.push({
       test: /\.(png|jpe?g|gif|webm)$/i,

--- a/src/pages/samples/videoUploadingWebCodecs.tsx
+++ b/src/pages/samples/videoUploadingWebCodecs.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+
+function Page(): JSX.Element {
+  return (
+    <Head>
+      <meta
+        httpEquiv="refresh"
+        content={`0; url=${
+          process.env.BASE_PATH || ''
+        }/samples/videoUploading?videoSource=videoFrame`}
+      ></meta>
+    </Head>
+  );
+}
+
+export default Page;


### PR DESCRIPTION
Next.js redirects don't work for static-site generation because it can't generate a .html file for the page.

Follow-up on #364 and #365