### PR TITLE
support light/dark

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
           <div class="sampleContainer"></div>
         </div>
         <nav id="code" class="sourceFileNav">
-          <div>
+          <div class="sourceFileScrollContainer">
             <ul id="codeTabs"></ul>
           </div>
         </nav>

--- a/public/css/HomePage.css
+++ b/public/css/HomePage.css
@@ -1,4 +1,41 @@
+:root {
+  color-scheme: light dark;
+
+  /* these are the light colors */
+  --background: #eee;
+
+  --code-background: #ccc;
+  --link: #045b88;
+
+  --panel-color: #000;
+  --panel-background: #ddd;
+  --panel-emphasis: rgb(20, 62, 84);
+
+  --tooltip-background: #eee;
+  --tooltip-border: rgba(0, 0, 0, 0.1);
+
+  --source-tab-color: white;
+  --source-tab-background: #444;
+  --source-tab-active-background: #282828;
+  --source-tab-active-shadow: rgb(167, 167, 167);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* these are the dark colors */
+    --background: #000;
+
+    --code-background: #555;
+    --link: #02abff;
+
+    --panel-color: #02abff;
+    --panel-background: #222;
+    --panel-emphasis: rgb(115, 206, 255);
+
+    --tooltip-background: #111;
+    --tooltip-border: rgba(255, 255, 255, 0.1);
+  }
+}
+
 .homePage {
-  background: white;
-  color: #222;
 }

--- a/public/css/MainLayout.css
+++ b/public/css/MainLayout.css
@@ -12,9 +12,10 @@
   flex: 1 0 auto;
   max-width: 300px;
   height: 100%;
-  background: #fafafa;
   overflow-y: auto;
   position: relative;
+  color: var(--panel-color);
+  background-color: var(--panel-background);
 }
 
 .exampleList {
@@ -24,7 +25,13 @@
 }
 
 .exampleList h3 {
-  color: rgb(43, 126, 171);
+  color: var(--panel-emphasis);
+}
+
+code {
+  background-color: var(--code-background);
+  border: 2px solid var(--code-background);
+  border-radius: 0.25em;
 }
 
 .exampleList li {
@@ -90,5 +97,6 @@ main {
   .expand {
     display: inline-block;
   }
+
 }
 

--- a/public/css/SampleLayout.css
+++ b/public/css/SampleLayout.css
@@ -13,13 +13,15 @@
   height: 100%;
   border: none;
   display: block;
+  /* should should remain white because samples in iframes expect a white background */
+  color-scheme: light;
   background-color: #fff;
 }
 
 .sampleCategory {
-  margin-top: 5px;
-  margin-bottom: 5px;
-  display: inline-block;
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
+  position: relative;
 }
 
 [data-tooltip] {
@@ -29,8 +31,8 @@
 [data-tooltip]::after {
   pointer-events: none;
   content: attr(data-tooltip);
-  background-color: rgba(255, 255, 255, 1);
-  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.1);
+  background-color: var(--tooltip-background);
+  box-shadow: 0 0 2px 2px var(--tooltip-border);
   border-radius: 10px;
   transition: opacity 0.2s ease-in, transform 0.2s ease-out;
   padding: 0.5em;
@@ -43,9 +45,6 @@
 [data-tooltip]:hover::after {
   opacity: 1;
   transform: translateY(0.25em);
-}
-
-nav.sourceFileNav {
 }
 
 nav.sourceFileNav ul {
@@ -98,39 +97,12 @@ nav.sourceFileNav[data-right=true]::after {
   background: linear-gradient(270deg, rgba(0, 0, 0, 0.35), transparent);
 }
 
-nav.sourceFileNav div.sourceFileScrollContainer {
-  white-space: nowrap;
-  overflow-x: auto;
-  scrollbar-width: thin;
-}
-
-nav.sourceFileNav div.sourceFileScrollContainer::-webkit-scrollbar {
-  display: inline;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  height: 11px;
-  width: 10px;
-}
-
-nav.sourceFileNav div.sourceFileScrollContainer::-webkit-scrollbar-thumb {
-  background: rgb(200, 200, 200);
-  height: 4px;
-  border-radius: 20px;
-  -webkit-box-shadow: inset 0px 0px 10px rgb(45, 33, 33);
-  border: 0.5px solid transparent;
-  background-clip: content-box;
-}
-
-nav.sourceFileNav div.sourceFileScrollContainer::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0);
-}
-
 nav.sourceFileNav li a {
   display: block;
   margin: 0;
   padding: 10px;
-  color: white;
-  background-color: #403e3e;
+  color: var(--source-tab-color);
+  background-color: var(--source-tab-background);
 }
 
 nav.sourceFileNav li:hover {
@@ -140,11 +112,11 @@ nav.sourceFileNav li:hover {
 }
 
 nav.sourceFileNav li a[data-active=true] {
-  background-color: #282823;
+  background-color: var(--source-tab-active-background);
 }
 
 nav.sourceFileNav li:has(a[data-active=true]) {
-  box-shadow: 0 -10px 0 0 rgb(167, 167, 167);
+  box-shadow: 0 -10px 0 0 var(--source-tab-active-shadow);
   border-radius: 10px;
 }
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -2,7 +2,6 @@
 @import url('MainLayout.css');
 @import url('SampleLayout.css');
 
-
 * {
   box-sizing: border-box;
 }
@@ -10,6 +9,7 @@
 html, body {
   margin: 0;
   height: 100%;
+  background-color: var(--background);
 }
 
 body {
@@ -18,11 +18,7 @@ body {
 
 a {
   text-decoration: none;
-}
-
-a:link,
-a:visited {
-  color: #045b88;
+  color: var(--link)
 }
 
 a:hover {
@@ -34,8 +30,6 @@ main {
   flex-direction: column;
   position: relative;
   flex: 1;
-  background: black;
-  color: #ddd;
   padding-left: 15px;
   padding-right: 15px;
 }

--- a/public/menu.svg
+++ b/public/menu.svg
@@ -1,4 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000">
+    <defs>
+    <style>
+        .menu-icon-color {
+            fill: #000;
+        }
+        @media (prefers-color-scheme: dark) {
+          .menu-icon-color {
+            fill: #eeeeee;
+          }
+        }
+    </style>
+    </defs>
     <path d="M0 0h24v24H0z" fill="none"/>
-    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
+    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" class="menu-icon-color"/>
 </svg>


### PR DESCRIPTION
No worries if this is not desired. I just thought I'd take a stab at it.

Here's the results

<img width="1123" alt="Screenshot 2024-03-11 at 21 19 23" src="https://github.com/webgpu/webgpu-samples/assets/234804/df513c46-3fdd-4dd9-b590-83d6fbfdebd7">

---

<img width="1130" alt="Screenshot 2024-03-11 at 21 21 33" src="https://github.com/webgpu/webgpu-samples/assets/234804/09391c28-3ffb-4716-941f-a651275c8747">

I can look into the codemirror stuff later.

#392

note: read this and 😭
https://fvsch.com/transparent-iframes

This works for Safari and Chrome but AFAICT there is no solution on Firefox. There, samples are always white ATM. Maybe there is though and I just didn't find it.