### PR TITLE
Use sampleCount with Render Pipeline

### DIFF
--- a/sample/helloTriangleMSAA/main.ts
+++ b/sample/helloTriangleMSAA/main.ts
@@ -41,7 +41,7 @@ const pipeline = device.createRenderPipeline({
     topology: 'triangle-list',
   },
   multisample: {
-    count: 4,
+    count: sampleCount,
   },
 });
 

--- a/sample/resizeCanvas/main.ts
+++ b/sample/resizeCanvas/main.ts
@@ -42,7 +42,7 @@ const pipeline = device.createRenderPipeline({
     topology: 'triangle-list',
   },
   multisample: {
-    count: 4,
+    count: sampleCount,
   },
 });
 


### PR DESCRIPTION
Since the count in multisample of Render Pipeline and texture must match, using the sampleCount makes reading a bit more easier.

Thank you!