### PR TITLE
Put search UI at top of editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.2",
+        "@codemirror/search": "^6.5.6",
         "@codemirror/view": "^6.28.1",
         "@uiw/codemirror-theme-github": "^4.22.2",
         "@uiw/codemirror-theme-monokai": "^4.22.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.2",
+    "@codemirror/search": "^6.5.6",
     "@codemirror/view": "^6.28.1",
     "@uiw/codemirror-theme-github": "^4.22.2",
     "@uiw/codemirror-theme-monokai": "^4.22.2",

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -46,3 +46,7 @@ main {
   height: auto !important;
   overflow: visible !important;
 }
+
+.cm-editor {
+  max-height: 100vh;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { monokai } from '@uiw/codemirror-theme-monokai';
 import { githubLight } from '@uiw/codemirror-theme-github';
 import { EditorView } from '@codemirror/view';
 import { EditorState, Compartment } from '@codemirror/state';
+import { search } from '@codemirror/search';
 import { javascript } from '@codemirror/lang-javascript';
 import { basicSetup } from 'codemirror';
 import { Converter } from 'showdown';
@@ -64,6 +65,7 @@ async function makeCodeMirrorEditor(parent: HTMLElement, filename: string) {
       themeConfig.of([getCodeMirrorTheme()]),
       EditorView.lineWrapping,
       javascript(),
+      search({ top: true }),
       readOnly,
     ],
     parent,


### PR DESCRIPTION
Also, make max editor size to be 100vh

Hopefully that provides a better UX as it
keeps the search area on the screen.

It's not perfect because until the search UI hits the top of the screen it keeps moving so you have to chase it with your mouse. Putting at the bottom doesn't work because it's off the screen by default.

I spent a few minutes trying to make it hover at the bottom but failed.

Ultimately I'm mixed on the point. The code is on github. We could just have a link to the correct folder on github.