### PR TITLE
Enclose all URLs in descriptions with <> syntax

### DIFF
--- a/sample/bitonicSort/meta.ts
+++ b/sample/bitonicSort/meta.ts
@@ -1,7 +1,7 @@
 export default {
   name: 'Bitonic Sort',
   description:
-    "A naive bitonic sort algorithm executed on the GPU, based on tgfrerer's implementation at [https://poniesandlight.co.uk/reflect/bitonic&lowbar;merge&lowbar;sort/](https://poniesandlight.co.uk/reflect/bitonic_merge_sort/). Each dispatch of the bitonic sort shader dispatches a workgroup containing elements/2 invocations. The GUI's Execution Information folder contains information about the sort's current state. The visualizer displays the sort's results as colored cells sorted from brightest to darkest.",
+    "A naive bitonic sort algorithm executed on the GPU, based on tgfrerer's implementation at <https://poniesandlight.co.uk/reflect/bitonic_merge_sort/>. Each dispatch of the bitonic sort shader dispatches a workgroup containing elements/2 invocations. The GUI's Execution Information folder contains information about the sort's current state. The visualizer displays the sort's results as colored cells sorted from brightest to darkest.",
   filename: __DIRNAME__,
   sources: [
     { path: 'main.ts' },

--- a/sample/bundleCulling/meta.ts
+++ b/sample/bundleCulling/meta.ts
@@ -2,7 +2,7 @@ export default {
   name: 'Bundle Culling',
   description: `A demonstration of using frustum culling with render bundles through indirect instanced draw calls.
 
-Source at https://github.com/toji/webgpu-bundle-culling/
+Source at <https://github.com/toji/webgpu-bundle-culling/>
 `,
   filename: __DIRNAME__,
   url: 'https://toji.github.io/webgpu-bundle-culling/',

--- a/sample/clusteredShading/meta.ts
+++ b/sample/clusteredShading/meta.ts
@@ -2,7 +2,7 @@ export default {
   name: 'Clustered Shading',
   description: `Shows a simple clustered forward shading renderer.
 
-Source at https://github.com/toji/webgpu-clustered-shading/
+Source at <https://github.com/toji/webgpu-clustered-shading/>
 `,
   filename: __DIRNAME__,
   url: 'https://toji.github.io/webgpu-clustered-shading/',

--- a/sample/cubemap/meta.ts
+++ b/sample/cubemap/meta.ts
@@ -1,7 +1,7 @@
 export default {
   name: 'Cubemap',
   description:
-    'This example shows how to render and sample from a cubemap texture. Cubemap image available under a Creative Commons Attribution 3.0 Unported License at https://www.humus.name/index.php?page=Textures&ID=58',
+    'This example shows how to render and sample from a cubemap texture. Cubemap image available under a Creative Commons Attribution 3.0 Unported License at <https://www.humus.name/index.php?page=Textures&ID=58>',
   filename: __DIRNAME__,
   sources: [
     { path: 'main.ts' },

--- a/sample/pristineGrid/meta.ts
+++ b/sample/pristineGrid/meta.ts
@@ -1,8 +1,8 @@
 export default {
   name: 'Pristine Grid',
-  description: `A simple WebGPU implementation of the "Pristine Grid" technique described in this wonderful little blog post: https://bgolus.medium.com/the-best-darn-grid-shader-yet-727f9278b9d8
+  description: `A simple WebGPU implementation of the "Pristine Grid" technique described in this wonderful little blog post: <https://bgolus.medium.com/the-best-darn-grid-shader-yet-727f9278b9d8>
 
-Source at https://github.com/toji/pristine-grid-webgpu/
+Source at <https://github.com/toji/pristine-grid-webgpu/>
 `,
   filename: __DIRNAME__,
   url: 'https://toji.github.io/pristine-grid-webgpu/',

--- a/sample/resizeObserverHDDPI/meta.ts
+++ b/sample/resizeObserverHDDPI/meta.ts
@@ -2,8 +2,8 @@ export default {
   name: 'ResizeObserver HD-DPI Fullscreen',
   description: `This example shows how to use ResizeObserver, handle HD-DPI correctly, and Fullscreen
   
-There should be no [Moiré patterns](https://www.google.com/search?q=Moir%C3%A9%20pattern) regardless of zoom level.  
-<sup>(<a href="https://caniuse.com/mdn-api_resizeobserverentry_devicepixelcontentboxsize">except possibly in Safari</a>)</sup>`,
+There should be no [Moiré patterns](https://www.google.com/search?q=Moir%C3%A9%20pattern) regardless of zoom level
+(... [except possibly in Safari](https://caniuse.com/mdn-api_resizeobserverentry_devicepixelcontentboxsize)).`,
   filename: __DIRNAME__,
   sources: [{ path: 'main.ts' }, { path: 'checker.wgsl' }],
 };

--- a/sample/reversedZ/meta.ts
+++ b/sample/reversedZ/meta.ts
@@ -8,9 +8,9 @@ To use reversed z to render your scene, you will need depth store value to be 0.
 and remap depth range by multiplying an additional matrix to your projection matrix.
 
 Related reading:
-  - https://developer.nvidia.com/content/depth-precision-visualized
-  - https://web.archive.org/web/20220724174000/
-  - https://thxforthefish.com/posts/reverse_z/
+  - <https://developer.nvidia.com/content/depth-precision-visualized>
+  - <https://web.archive.org/web/20220724174000/>
+  - <https://thxforthefish.com/posts/reverse_z/>
     `,
   filename: __DIRNAME__,
   sources: [

--- a/sample/skinnedMesh/meta.ts
+++ b/sample/skinnedMesh/meta.ts
@@ -1,7 +1,7 @@
 export default {
   name: 'Skinned Mesh',
   description:
-    'A demonstration of basic gltf loading and mesh skinning, ported from https://webgl2fundamentals.org/webgl/lessons/webgl-skinning.html. Mesh data, per vertex attributes, and skin inverseBindMatrices are taken from the json parsed from the binary output of the .glb file. Animations are generated progrmatically, with animated joint matrices updated and passed to shaders per frame via uniform buffers.',
+    'A demonstration of basic gltf loading and mesh skinning, ported from <https://webgl2fundamentals.org/webgl/lessons/webgl-skinning.html>. Mesh data, per vertex attributes, and skin inverseBindMatrices are taken from the json parsed from the binary output of the .glb file. Animations are generated progrmatically, with animated joint matrices updated and passed to shaders per frame via uniform buffers.',
   filename: __DIRNAME__,
   sources: [
     { path: 'main.ts' },

--- a/sample/spookyball/meta.ts
+++ b/sample/spookyball/meta.ts
@@ -2,7 +2,7 @@ export default {
   name: 'Spookyball',
   description: `This example shows a simple game made with WebGPU.
 
-Source at https://github.com/toji/spookyball
+Source at <https://github.com/toji/spookyball>
 `,
   filename: __DIRNAME__,
   url: 'https://spookyball.com',


### PR DESCRIPTION
This markdown syntax guarantees the link will be correctly detected, instead of relying on autodetection (which could miss some URLs, pick up adjacent punctuation, etc.)