### PR TITLE
Fix permalinking for particles demo

### DIFF
--- a/sample/particles/meta.ts
+++ b/sample/particles/meta.ts
@@ -1,5 +1,6 @@
 export default {
   name: 'Particles (HDR)',
+  tocName: 'particles (HDR)',
   description:
     'This example demonstrates rendering of particles (using HDR capabilities when possible) simulated with compute shaders.',
   filename: __DIRNAME__,

--- a/src/samples.ts
+++ b/src/samples.ts
@@ -118,7 +118,7 @@ export const pageCategories: PageCategory[] = [
       normalMap,
       shadowMapping,
       deferredRendering,
-      'particles (HDR)': particles,
+      particles,
       points,
       imageBlur,
       cornell,


### PR DESCRIPTION
Makes the link <https://webgpu.github.io/webgpu-samples/?sample=particles> work again

Fix for #432