### PR TITLE
Some mobile browsers require playsInline to be set to true for the video

### DIFF
--- a/sample/videoUploading/main.ts
+++ b/sample/videoUploading/main.ts
@@ -10,6 +10,7 @@ quitIfWebGPUNotAvailable(adapter, device);
 // Set video element
 const video = document.createElement('video');
 video.loop = true;
+video.playsInline = true;
 video.autoplay = true;
 video.muted = true;
 video.src = '../../assets/video/pano.webm';

--- a/sample/videoUploading/video.ts
+++ b/sample/videoUploading/video.ts
@@ -7,6 +7,7 @@ export default async function ({ useVideoFrame }: { useVideoFrame: boolean }) {
   // Set video element
   const video = document.createElement('video');
   video.loop = true;
+  video.playsInline = true;
   video.autoplay = true;
   video.muted = true;
   video.src = '../../assets/video/pano.webm';


### PR DESCRIPTION
Some mobile browsers require playsInline to be set to true for the video to play with the rest of the content.

To avoid WebGPU samples testing differences between mobile and desktop browsers, set playsInline = true prior to playing the video.