### PR TITLE
alphaToCoverage: show resolve result; draw twice with different colors/alphas

### DIFF
--- a/sample/alphaToCoverage/meta.ts
+++ b/sample/alphaToCoverage/meta.ts
@@ -1,23 +1,20 @@
 export default {
   name: 'Alpha-to-Coverage',
   description: `
-Visualizes how alpha-to-coverage translates alpha values into sample
-coverage on your device. It draws two full-screen quads into a 4-sample
-texture, with the configured color and alpha values. Then, it visualizes the
-contents of that 4-sample texture: the circles show the 4 samples of each
-pixel; the background checkerboard shows where the pixels are.
-
-The algorithm that converts alpha to a coverage sample mask varies per
-device. This results in different proportions between the black background,
-the first draw, and the second draw.
-
-Examples: Some devices use 1x1 patterns, others 2x2, others 4x4. Not all devices
-guarantee that once a sample "pops in", it will stay there at higher alpha
-values. Some devices "move" samples around at certain alpha thresholds even
-without increasing the total sample count.
-
-More info on alpha-to-coverage:
+Alpha-to-coverage is an alternative to alpha testing and alpha blending. See:
 <https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f>
+
+This sample visualizes how alpha-to-coverage translates alpha values into sample
+coverage on your device. It draws two full-screen quads into a 4-sample
+texture, each with the configured color and alpha value. Then, it visualizes the
+contents of the resulting 4-sample texture: the circles show the 4 samples of
+each texel; the background shows the "resolved" results (average of 4 samples).
+
+The algorithm that converts alpha to a coverage sample mask varies per device.
+This results in different average "blending" proportions between the black
+background, the first draw, and the second draw.
+Device differences include different tile sizes (e.g. 1x1, 2x2, or 4x4),
+"moving" samples (or not) around with in the tile as alpha increases, etc.
 `,
   filename: __DIRNAME__,
   sources: [

--- a/sample/alphaToCoverage/meta.ts
+++ b/sample/alphaToCoverage/meta.ts
@@ -11,7 +11,10 @@ The algorithm that converts alpha to a coverage sample mask varies per
 device. This results in different proportions between the black background,
 the first draw, and the second draw.
 
-Examples: Some devices use 1x1 patterns, others 2x2, others 4x4. Not all devices guarantee that once a sample "pops in", it will stay there at higher alpha values. Some devices "move" samples around at certain alpha thresholds even without increasing the total sample count.
+Examples: Some devices use 1x1 patterns, others 2x2, others 4x4. Not all devices
+guarantee that once a sample "pops in", it will stay there at higher alpha
+values. Some devices "move" samples around at certain alpha thresholds even
+without increasing the total sample count.
 `,
   filename: __DIRNAME__,
   sources: [

--- a/sample/alphaToCoverage/meta.ts
+++ b/sample/alphaToCoverage/meta.ts
@@ -1,7 +1,19 @@
 export default {
   name: 'Alpha-to-Coverage',
   description:
-    'Visualizes how alpha-to-coverage translates alpha values into sample coverage on your device. This varies per device; for example, not all devices guarantee that once a sample pops in, it will stay; some devices repeat at 2x2 pixels, others at 4x4; etc. The circles show the 4 samples of each pixel; the background checkerboard shows where the pixels are.',
+    `
+Visualizes how alpha-to-coverage translates alpha values into sample
+coverage on your device. It draws two full-screen quads into a 4-sample
+texture, with the configured color and alpha values. Then, it visualizes the
+contents of that 4-sample texture: the circles show the 4 samples of each
+pixel; the background checkerboard shows where the pixels are.
+
+The algorithm that converts alpha to a coverage sample mask varies per
+device. This results in different proportions between the black background,
+the first draw, and the second draw.
+
+Examples: Some devices use 1x1 patterns, others 2x2, others 4x4. Not all devices guarantee that once a sample "pops in", it will stay there at higher alpha values. Some devices "move" samples around at certain alpha thresholds even without increasing the total sample count.
+    `,
   filename: __DIRNAME__,
   sources: [
     { path: 'main.ts' },

--- a/sample/alphaToCoverage/meta.ts
+++ b/sample/alphaToCoverage/meta.ts
@@ -15,6 +15,9 @@ Examples: Some devices use 1x1 patterns, others 2x2, others 4x4. Not all devices
 guarantee that once a sample "pops in", it will stay there at higher alpha
 values. Some devices "move" samples around at certain alpha thresholds even
 without increasing the total sample count.
+
+More info on alpha-to-coverage:
+<https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f>
 `,
   filename: __DIRNAME__,
   sources: [

--- a/sample/alphaToCoverage/meta.ts
+++ b/sample/alphaToCoverage/meta.ts
@@ -1,7 +1,6 @@
 export default {
   name: 'Alpha-to-Coverage',
-  description:
-    `
+  description: `
 Visualizes how alpha-to-coverage translates alpha values into sample
 coverage on your device. It draws two full-screen quads into a 4-sample
 texture, with the configured color and alpha values. Then, it visualizes the
@@ -13,7 +12,7 @@ device. This results in different proportions between the black background,
 the first draw, and the second draw.
 
 Examples: Some devices use 1x1 patterns, others 2x2, others 4x4. Not all devices guarantee that once a sample "pops in", it will stay there at higher alpha values. Some devices "move" samples around at certain alpha thresholds even without increasing the total sample count.
-    `,
+`,
   filename: __DIRNAME__,
   sources: [
     { path: 'main.ts' },

--- a/sample/alphaToCoverage/renderWithAlphaToCoverage.wgsl
+++ b/sample/alphaToCoverage/renderWithAlphaToCoverage.wgsl
@@ -1,26 +1,24 @@
-struct Config {
-  alpha: f32,
-};
-@group(0) @binding(0) var<uniform> config: Config;
-
 struct Varying {
   @builtin(position) pos: vec4f,
+  // Color from instance-step-mode vertex buffer
+  @location(0) color: vec4f,
 }
 
 @vertex
 fn vmain(
   @builtin(vertex_index) vertex_index: u32,
+  @location(0) color: vec4f,
 ) -> Varying {
   var square = array(
     vec2f(-1, -1), vec2f(-1,  1), vec2f( 1, -1),
     vec2f( 1, -1), vec2f(-1,  1), vec2f( 1,  1),
   );
 
-  return Varying(vec4(square[vertex_index], 0, 1));
+  return Varying(vec4(square[vertex_index], 0, 1), color);
 }
 
 @fragment
 fn fmain(vary: Varying) -> @location(0) vec4f {
-  return vec4f(1, 1, 1, config.alpha);
+  return vary.color;
 }
 

--- a/sample/alphaToCoverage/showMultisampleTexture.wgsl
+++ b/sample/alphaToCoverage/showMultisampleTexture.wgsl
@@ -50,7 +50,7 @@ fn fmain(vary: Varying) -> @location(0) vec4f {
   let xyFrac = xy % vec2f(1, 1);
 
   // Show the visualization only if the resolution is large enough to see it
-  if (dpdx(xy.x) < kGridEdgeHalfWidth) & (dpdy(xy.y) < kGridEdgeHalfWidth) {
+  if (dpdx(xy.x) < kGridEdgeHalfWidth * 2) & (dpdy(xy.y) < kGridEdgeHalfWidth * 2) {
     // Check if we're close to a sample; if so, visualize the sample value
     for (var sampleIndex = 0; sampleIndex < kSampleCount; sampleIndex += 1) {
       let distanceFromSample = distance(xyFrac, kSamplePositions[sampleIndex]);

--- a/sample/alphaToCoverage/showMultisampleTexture.wgsl
+++ b/sample/alphaToCoverage/showMultisampleTexture.wgsl
@@ -1,4 +1,5 @@
 @group(0) @binding(0) var tex: texture_multisampled_2d<f32>;
+@group(0) @binding(1) var resolved: texture_2d<f32>;
 
 struct Varying {
   @builtin(position) pos: vec4f,
@@ -24,6 +25,7 @@ fn vmain(
   return Varying(pos, uv);
 }
 
+// Standard sample positions for 4xMSAA (assuming the device conforms to spec)
 const kSampleCount = 4;
 const kSamplePositions: array<vec2f, kSampleCount> = array(
   vec2f(0.375, 0.125),
@@ -31,6 +33,12 @@ const kSamplePositions: array<vec2f, kSampleCount> = array(
   vec2f(0.125, 0.625),
   vec2f(0.625, 0.875),
 );
+
+// Compute dimensions for drawing a nice-looking visualization
+const kSampleDistanceFromCloseEdge = 0.125; // from the standard sample positions
+const kGridEdgeHalfWidth = 0.025;
+const kSampleInnerRadius = kSampleDistanceFromCloseEdge - kGridEdgeHalfWidth;
+const kSampleOuterRadius = kSampleDistanceFromCloseEdge + kGridEdgeHalfWidth;
 
 @fragment
 fn fmain(vary: Varying) -> @location(0) vec4f {
@@ -45,14 +53,27 @@ fn fmain(vary: Varying) -> @location(0) vec4f {
     return vec4f(0, 0, 0, 1);
   }
 
-  // check if we're close to a sample, and return it
+  // Check if we're close to a sample, and return it
   for (var sampleIndex = 0; sampleIndex < kSampleCount; sampleIndex += 1) {
-    if distance(xyFrac, kSamplePositions[sampleIndex]) < 0.1 {
+    let distanceFromSample = distance(xyFrac, kSamplePositions[sampleIndex]);
+    if distanceFromSample < kSampleInnerRadius {
+      // Draw a circle for the sample value
       let val = textureLoad(tex, xyInt, sampleIndex).rgb;
       return vec4f(val, 1);
+    } else if distanceFromSample < kSampleOuterRadius {
+      // Draw a ring around the circle
+      return vec4f(0, 0, 0, 1);
     }
+
   }
 
-  // if not close to a sample, render background checkerboard
-  return vec4f(f32(xyInt.x % 4 + 1) / 8, 0, f32(xyInt.y % 4 + 1) / 8, 1);
+  // If close to a grid edge, render the grid
+  let distanceToGridEdge = abs((xyFrac + 0.5) % 1 - 0.5);
+  if min(distanceToGridEdge.x, distanceToGridEdge.y) < kGridEdgeHalfWidth {
+    return vec4f(0, 0, 0, 1);
+  }
+
+  // Otherwise, show the multisample-resolved result as the background
+  let val = textureLoad(resolved, xyInt, /*level*/ 0).rgb;
+  return vec4f(val, 1);
 }

--- a/sample/alphaToCoverage/showMultisampleTexture.wgsl
+++ b/sample/alphaToCoverage/showMultisampleTexture.wgsl
@@ -49,28 +49,26 @@ fn fmain(vary: Varying) -> @location(0) vec4f {
   let xyInt = vec2u(xy);
   let xyFrac = xy % vec2f(1, 1);
 
-  if xyInt.x >= dim.x || xyInt.y >= dim.y {
-    return vec4f(0, 0, 0, 1);
-  }
-
-  // Check if we're close to a sample, and return it
-  for (var sampleIndex = 0; sampleIndex < kSampleCount; sampleIndex += 1) {
-    let distanceFromSample = distance(xyFrac, kSamplePositions[sampleIndex]);
-    if distanceFromSample < kSampleInnerRadius {
-      // Draw a circle for the sample value
-      let val = textureLoad(tex, xyInt, sampleIndex).rgb;
-      return vec4f(val, 1);
-    } else if distanceFromSample < kSampleOuterRadius {
-      // Draw a ring around the circle
-      return vec4f(0, 0, 0, 1);
+  // Show the visualization only if the resolution is large enough to see it
+  if (dpdx(xy.x) < kGridEdgeHalfWidth) & (dpdy(xy.y) < kGridEdgeHalfWidth) {
+    // Check if we're close to a sample; if so, visualize the sample value
+    for (var sampleIndex = 0; sampleIndex < kSampleCount; sampleIndex += 1) {
+      let distanceFromSample = distance(xyFrac, kSamplePositions[sampleIndex]);
+      if distanceFromSample < kSampleInnerRadius {
+        // Draw a circle for the sample value
+        let val = textureLoad(tex, xyInt, sampleIndex).rgb;
+        return vec4f(val, 1);
+      } else if distanceFromSample < kSampleOuterRadius {
+        // Draw a ring around the circle
+        return vec4f(0, 0, 0, 1);
+      }
     }
 
-  }
-
-  // If close to a grid edge, render the grid
-  let distanceToGridEdge = abs((xyFrac + 0.5) % 1 - 0.5);
-  if min(distanceToGridEdge.x, distanceToGridEdge.y) < kGridEdgeHalfWidth {
-    return vec4f(0, 0, 0, 1);
+    // If close to a grid edge, render the grid
+    let distanceToGridEdge = abs((xyFrac + 0.5) % 1 - 0.5);
+    if min(distanceToGridEdge.x, distanceToGridEdge.y) < kGridEdgeHalfWidth {
+      return vec4f(0, 0, 0, 1);
+    }
   }
 
   // Otherwise, show the multisample-resolved result as the background


### PR DESCRIPTION
This demonstrates how different alpha-to-coverage algorithms produce different blending results.

![image](https://github.com/user-attachments/assets/5b9a6cd9-c4f7-41f7-9fae-58c159f8d0ef)
