### PR TITLE
Use transparency in helloTriangle*, remove alphaMode on rest

### DIFF
--- a/sample/alphaToCoverage/main.ts
+++ b/sample/alphaToCoverage/main.ts
@@ -69,7 +69,6 @@ const context = canvas.getContext('webgpu') as GPUCanvasContext;
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 //

--- a/sample/animometer/main.ts
+++ b/sample/animometer/main.ts
@@ -39,7 +39,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
   usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
 });
 

--- a/sample/bitonicSort/utils.ts
+++ b/sample/bitonicSort/utils.ts
@@ -134,7 +134,6 @@ export const SampleInitFactoryWebGPU = async (
     context.configure({
       device,
       format: presentationFormat,
-      alphaMode: 'premultiplied',
     });
 
     callback({

--- a/sample/cameras/main.ts
+++ b/sample/cameras/main.ts
@@ -53,7 +53,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 // Create a vertex buffer from the cube data.

--- a/sample/computeBoids/main.ts
+++ b/sample/computeBoids/main.ts
@@ -39,7 +39,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const spriteShaderModule = device.createShaderModule({ code: spriteWGSL });

--- a/sample/cornell/main.ts
+++ b/sample/cornell/main.ts
@@ -46,7 +46,6 @@ context.configure({
   device,
   format: presentationFormat,
   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
-  alphaMode: 'premultiplied',
 });
 
 const framebuffer = device.createTexture({

--- a/sample/cubemap/main.ts
+++ b/sample/cubemap/main.ts
@@ -27,7 +27,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 // Create a vertex buffer from the cube data.

--- a/sample/deferredRendering/main.ts
+++ b/sample/deferredRendering/main.ts
@@ -29,7 +29,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 // Create the model vertex buffer.

--- a/sample/fractalCube/main.ts
+++ b/sample/fractalCube/main.ts
@@ -31,7 +31,6 @@ context.configure({
   // Specify we want both RENDER_ATTACHMENT and COPY_SRC since we
   // will copy out of the swapchain texture.
   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-  alphaMode: 'premultiplied',
 });
 
 // Create a vertex buffer from the cube data.

--- a/sample/gameOfLife/main.ts
+++ b/sample/gameOfLife/main.ts
@@ -18,7 +18,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const GameOptions = {

--- a/sample/helloTriangle/main.ts
+++ b/sample/helloTriangle/main.ts
@@ -50,7 +50,7 @@ function frame() {
     colorAttachments: [
       {
         view: textureView,
-        clearValue: [0, 0, 0, 1],
+        clearValue: [0, 0, 0, 0], // Clear to transparent
         loadOp: 'clear',
         storeOp: 'store',
       },

--- a/sample/helloTriangleMSAA/main.ts
+++ b/sample/helloTriangleMSAA/main.ts
@@ -63,7 +63,7 @@ function frame() {
       {
         view,
         resolveTarget: context.getCurrentTexture().createView(),
-        clearValue: [0, 0, 0, 1],
+        clearValue: [0, 0, 0, 0], // Clear to transparent
         loadOp: 'clear',
         storeOp: 'discard',
       },

--- a/sample/imageBlur/main.ts
+++ b/sample/imageBlur/main.ts
@@ -22,7 +22,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const blurPipeline = device.createComputePipeline({

--- a/sample/instancedCube/main.ts
+++ b/sample/instancedCube/main.ts
@@ -27,7 +27,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 // Create a vertex buffer from the cube data.

--- a/sample/normalMap/main.ts
+++ b/sample/normalMap/main.ts
@@ -29,7 +29,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 interface GUISettings {

--- a/sample/occlusionQuery/main.ts
+++ b/sample/occlusionQuery/main.ts
@@ -44,7 +44,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 const depthFormat = 'depth24plus';
 

--- a/sample/particles/main.ts
+++ b/sample/particles/main.ts
@@ -33,7 +33,6 @@ function configureContext() {
     device,
     format: presentationFormat,
     toneMapping: { mode: simulationParams.toneMappingMode },
-    alphaMode: 'premultiplied',
   });
 }
 

--- a/sample/renderBundles/main.ts
+++ b/sample/renderBundles/main.ts
@@ -40,7 +40,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const shaderModule = device.createShaderModule({

--- a/sample/resizeCanvas/main.ts
+++ b/sample/resizeCanvas/main.ts
@@ -18,7 +18,6 @@ canvas.height = canvas.clientHeight * devicePixelRatio;
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const sampleCount = 4;

--- a/sample/resizeObserverHDDPI/main.ts
+++ b/sample/resizeObserverHDDPI/main.ts
@@ -14,7 +14,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const module = device.createShaderModule({

--- a/sample/reversedZ/main.ts
+++ b/sample/reversedZ/main.ts
@@ -80,7 +80,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const verticesBuffer = device.createBuffer({

--- a/sample/rotatingCube/main.ts
+++ b/sample/rotatingCube/main.ts
@@ -27,7 +27,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 // Create a vertex buffer from the cube data.

--- a/sample/samplerParameters/main.ts
+++ b/sample/samplerParameters/main.ts
@@ -174,7 +174,6 @@ const context = canvas.getContext('webgpu') as GPUCanvasContext;
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 //

--- a/sample/shadowMapping/main.ts
+++ b/sample/shadowMapping/main.ts
@@ -23,7 +23,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 // Create the model vertex buffer.

--- a/sample/skinnedMesh/main.ts
+++ b/sample/skinnedMesh/main.ts
@@ -109,7 +109,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const settings = {

--- a/sample/textRenderingMsdf/main.ts
+++ b/sample/textRenderingMsdf/main.ts
@@ -29,7 +29,6 @@ const depthFormat = 'depth24plus';
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const textRenderer = new MsdfTextRenderer(

--- a/sample/texturedCube/main.ts
+++ b/sample/texturedCube/main.ts
@@ -27,7 +27,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 // Create a vertex buffer from the cube data.

--- a/sample/twoCubes/main.ts
+++ b/sample/twoCubes/main.ts
@@ -27,7 +27,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 // Create a vertex buffer from the cube data.

--- a/sample/videoUploading/main.ts
+++ b/sample/videoUploading/main.ts
@@ -26,7 +26,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const pipeline = device.createRenderPipeline({

--- a/sample/videoUploading/video.ts
+++ b/sample/videoUploading/video.ts
@@ -27,7 +27,6 @@ export default async function ({ useVideoFrame }: { useVideoFrame: boolean }) {
   context.configure({
     device,
     format: presentationFormat,
-    alphaMode: 'premultiplied',
   });
 
   const pipeline = device.createRenderPipeline({

--- a/sample/volumeRenderingTexture3D/main.ts
+++ b/sample/volumeRenderingTexture3D/main.ts
@@ -33,7 +33,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 
 const pipeline = device.createRenderPipeline({

--- a/sample/wireframe/main.ts
+++ b/sample/wireframe/main.ts
@@ -74,7 +74,6 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 context.configure({
   device,
   format: presentationFormat,
-  alphaMode: 'premultiplied',
 });
 const depthFormat = 'depth24plus';
 

--- a/sample/worker/worker.ts
+++ b/sample/worker/worker.ts
@@ -45,7 +45,6 @@ async function init(canvas) {
   context.configure({
     device,
     format: presentationFormat,
-    alphaMode: 'premultiplied',
   });
 
   // Create a vertex buffer from the cube data.


### PR DESCRIPTION
None of the samples used transparent canvases, so they shouldn't set alphaMode.
We should demonstrate transparent canvases though, so I made the two helloTriangle samples do that.

Technically opaque canvases force an alpha clear on Mac, but probably we should stick to the spec default. Someday maybe we can do something about that alpha clear.