### PR TITLE
"Fix" clear value

### DIFF
--- a/sample/occlusionQuery/main.ts
+++ b/sample/occlusionQuery/main.ts
@@ -211,7 +211,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
   colorAttachments: [
     {
       view: undefined, // Assigned later
-      clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+      clearValue: [0.5, 0.5, 0.5, 1.0],
       loadOp: 'clear',
       storeOp: 'store',
     },


### PR DESCRIPTION
We previously set all clearValue settings to arrays. Arrays are arguably a better pattern as they directly map to TypedArrays and other forms of 4 values.