### PR TITLE
Fix toneMapping reference

### DIFF
--- a/sample/particles/main.ts
+++ b/sample/particles/main.ts
@@ -355,7 +355,7 @@ function getHdrFolderName() {
   }
   if (
     simulationParams.toneMappingMode === 'extended' &&
-    context.getConfiguration().toneMapping?.mode !== 'extended'
+    context.getConfiguration().toneMapping.mode !== 'extended'
   ) {
     return "HDR settings ⚠️ Browser doesn't support HDR canvas";
   }


### PR DESCRIPTION
AFAICT, the spec requires toneMapping period. Even if the browser doesn't support toneMapping.mode = 'extended' it requires it still requires it to exist. It will just be set to `'standard'` if the implementation does not support `'extended'`.

The only other case is when the canvas has not been configured in which case `getConfiguration` returns undefined.

Both `getConfiguration` and `toneMapping` were added to the spec close enough that any implemetation that supports `getConfiguration` should be requried to include `toneMapping`.