### PR TITLE
Update dead link to thxforthefish.com/ in reversedZ example

### DIFF
--- a/sample/reversedZ/meta.ts
+++ b/sample/reversedZ/meta.ts
@@ -10,7 +10,7 @@ and remap depth range by multiplying an additional matrix to your projection mat
 Related reading:
   - <https://developer.nvidia.com/content/depth-precision-visualized>
   - <https://web.archive.org/web/20220724174000/>
-  - <https://thxforthefish.com/posts/reverse_z/>
+  - <https://iolite-engine.com/blog_posts/reverse_z_cheatsheet>
     `,
   filename: __DIRNAME__,
   sources: [


### PR DESCRIPTION
"https://thxforthefish.com/posts/reverse_z/" redirects to the root of "https://iolite-engine.com" now, but it looks like the original blog was moved to "https://iolite-engine.com/blog_posts/reverse_z_cheatsheet".