### PR TITLE
Add "view as standalone webpage" link; improvements for external samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,8 @@
         <div id="sample" style="display: none;">
           <div class="sampleInfo">
             <h1 id="title"></h1>
-            <a id="src" target="_blank" rel="noreferrer" href="">See it on Github!</a>
+            <a id="src" target="_blank" rel="noreferrer" href="">View source!</a>
+            &mdash; <a id="standalone" target="_blank" rel="noreferrer" href="">View as standalone webpage</a>
             <p id="description"></p>
           </div>
           <div class="sampleContainer"></div>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -21,9 +21,13 @@ body {
 
 a {
   text-decoration: none;
-  color: var(--link)
+  color: var(--link);
 }
-
+a:not([href]), a[href=""] {
+  /* link is missing href */
+  text-decoration: wavy underline;
+  color: #f00;
+}
 a:hover {
   text-decoration: underline;
 }

--- a/sample/bundleCulling/meta.ts
+++ b/sample/bundleCulling/meta.ts
@@ -1,10 +1,10 @@
 export default {
   name: 'Bundle Culling',
-  description: `A demonstration of using frustum culling with render bundles through indirect instanced draw calls.
-
-Source at <https://github.com/toji/webgpu-bundle-culling/>
-`,
+  description: `A demonstration of using frustum culling with render bundles through indirect instanced draw calls.`,
   filename: __DIRNAME__,
-  url: 'https://toji.github.io/webgpu-bundle-culling/',
+  external: {
+    url: 'https://toji.github.io/webgpu-bundle-culling/',
+    sourceURL: 'https://github.com/toji/webgpu-bundle-culling',
+  },
   sources: [],
 };

--- a/sample/clusteredShading/meta.ts
+++ b/sample/clusteredShading/meta.ts
@@ -1,10 +1,10 @@
 export default {
   name: 'Clustered Shading',
-  description: `Shows a simple clustered forward shading renderer.
-
-Source at <https://github.com/toji/webgpu-clustered-shading/>
-`,
+  description: `Shows a simple clustered forward shading renderer.`,
   filename: __DIRNAME__,
-  url: 'https://toji.github.io/webgpu-clustered-shading/',
+  external: {
+    url: 'https://toji.github.io/webgpu-clustered-shading/',
+    sourceURL: 'https://github.com/toji/webgpu-clustered-shading',
+  },
   sources: [],
 };

--- a/sample/marchingCubes/meta.ts
+++ b/sample/marchingCubes/meta.ts
@@ -1,10 +1,10 @@
 export default {
   name: 'Marching Cubes',
-  description: `This example demonstrates how to dynamically generate procedural meshes using a signed distance field and a multi-pass marching cubes algorithm on the GPU.
-
-Source at <https://github.com/tcoppex/webgpu-marchingcubes>
-`,
+  description: `This example demonstrates how to dynamically generate procedural meshes using a signed distance field and a multi-pass marching cubes algorithm on the GPU.`,
   filename: __DIRNAME__,
-  url: 'https://tcoppex.github.io/webgpu-marchingcubes/',
+  external: {
+    url: 'https://tcoppex.github.io/webgpu-marchingcubes/',
+    sourceURL: 'https://github.com/tcoppex/webgpu-marchingcubes',
+  },
   sources: [],
 };

--- a/sample/metaballs/meta.ts
+++ b/sample/metaballs/meta.ts
@@ -1,10 +1,10 @@
 export default {
   name: 'Metaballs',
-  description: `This example shows an implementation of metaballs with WebGPU.
-
-Source at https://github.com/toji/webgpu-metaballs/
-`,
+  description: `This example shows an implementation of metaballs with WebGPU.`,
   filename: __DIRNAME__,
-  url: 'https://toji.github.io/webgpu-metaballs/',
+  external: {
+    url: 'https://toji.github.io/webgpu-metaballs/',
+    sourceURL: 'https://github.com/toji/webgpu-metaballs',
+  },
   sources: [],
 };

--- a/sample/pristineGrid/meta.ts
+++ b/sample/pristineGrid/meta.ts
@@ -1,10 +1,10 @@
 export default {
   name: 'Pristine Grid',
-  description: `A simple WebGPU implementation of the "Pristine Grid" technique described in this wonderful little blog post: <https://bgolus.medium.com/the-best-darn-grid-shader-yet-727f9278b9d8>
-
-Source at <https://github.com/toji/pristine-grid-webgpu/>
-`,
+  description: `A simple WebGPU implementation of the "Pristine Grid" technique described in this wonderful little blog post: <https://bgolus.medium.com/the-best-darn-grid-shader-yet-727f9278b9d8>`,
   filename: __DIRNAME__,
-  url: 'https://toji.github.io/pristine-grid-webgpu/',
+  external: {
+    url: 'https://toji.github.io/pristine-grid-webgpu/',
+    sourceURL: 'https://github.com/toji/pristine-grid-webgpu',
+  },
   sources: [],
 };

--- a/sample/spookyball/meta.ts
+++ b/sample/spookyball/meta.ts
@@ -1,10 +1,10 @@
 export default {
   name: 'Spookyball',
-  description: `This example shows a simple game made with WebGPU.
-
-Source at <https://github.com/toji/spookyball>
-`,
+  description: `This example shows a simple game made with WebGPU.`,
   filename: __DIRNAME__,
-  url: 'https://spookyball.com',
+  external: {
+    url: 'https://spookyball.com',
+    sourceURL: 'https://github.com/toji/spookyball',
+  },
   sources: [],
 };

--- a/src/samples.ts
+++ b/src/samples.ts
@@ -52,7 +52,7 @@ export type SampleInfo = {
   description: string;
   openInNewTab?: boolean;
   filename: string; // used if sample is local
-  url?: string; // used if sample is remote
+  external?: { url: string; sourceURL: string }; // used if sample is remote
   sources: SourceInfo[];
 };
 


### PR DESCRIPTION
- "View as a standalone webpage" does the same thing as "open in new tab" on the sidebar links.
- Fixed the sidebar links for external samples
- Made external sample source part of the metadata instead of putting it in each sample's description
- Highlight broken links (was mostly just useful for me while doing this change)

![image](https://github.com/user-attachments/assets/4f58d9a6-d512-40fa-af6e-175a5c5acb14)

![image](https://github.com/user-attachments/assets/baa23202-7f84-4765-ac52-5e0fa31955a1)
