### PR TITLE
Avoid superluminant value in transparentCanvas

### DIFF
--- a/sample/transparentCanvas/main.ts
+++ b/sample/transparentCanvas/main.ts
@@ -117,7 +117,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     {
       view: undefined, // Assigned later
 
-      clearValue: [0.5, 0.5, 0.5, 0.0], // Clear alpha to 0
+      clearValue: [0, 0, 0, 0], // Clear alpha to 0
       loadOp: 'clear',
       storeOp: 'store',
     },


### PR DESCRIPTION
Ugh, this is really easy to do accidentally. Got lucky and noticed that it rendered incorrectly on one of my displays (but not the other!)

https://gpuweb.github.io/gpuweb/#out-of-gamut-premultiplied-rgba-value