### PR TITLE
Fix the iframe background color

### DIFF
--- a/public/css/SampleLayout.css
+++ b/public/css/SampleLayout.css
@@ -13,9 +13,26 @@
   height: 100%;
   border: none;
   display: block;
-  /* should should remain white because samples in iframes expect a white background */
-  color-scheme: light;
+  /*
+   * iframe content inherits the background color of the iframe element 
+   * in the parent but, the content might expect the default white background
+   * so we set the iframe element's background to white
+  */
   background-color: #fff;
+  /*
+   * further, the browser will ignore the color scheme in the iframe content
+   * if it matches the one in the parent iframe element. In other words
+   *
+   *   * iframe element says 'color-scheme: light dark'.
+   *   * iframe content says 'color-scheme: light dark'.
+   *
+   * result: iframe content color-scheme setting is ignored and it gets
+   * the background color from the iframe element in the parent.
+   *
+   * Solution: set the iframe element color-scheme to initial. Now the
+   * iframe content's setting will be respected.
+   */
+  color-scheme: initial;
 }
 
 .sampleCategory {


### PR DESCRIPTION
Originally when I did this 8 months ago I set the CSS a certain way that works in Chrome but not Firefox. I filed a bug for Firefox

https://bugzilla.mozilla.org/show_bug.cgi?id=1885048

They pointed out the bug is in Chrome and Firefox is correct. I put the CSS to match what Firefox said was correct and found the corresponding bug in Chrome which was basically being ignored. (I can't seem to find the bug now)

Anyway, my understanding is, since the web started, iframes content gets the background color of the iframe element. Unless of course they set their own background color and that, with white being the default backgrounc color, most pages expect a white background and so iframe elements need have a white background otherwise content breaks.

Often colors are now set via `color-scheme` but color-scheme is ignored in the iframe content if its the same as the iframe element's color-scheme because otherwise the previous rule about background color would be un-enforced.

The solution appears to be, set the iframe element's color-scheme to "initial". Now the iframe's content color-scheme setting is not ignored.

Safari - Light

<img width="1564" alt="Screenshot 2024-11-15 at 9 28 28" src="https://github.com/user-attachments/assets/196f9e32-3313-4453-9521-6fae4298ae15">

Safari - Dark

<img width="1564" alt="Screenshot 2024-11-15 at 7 57 47" src="https://github.com/user-attachments/assets/68c6784b-7357-49e1-bd87-1ae141d0adaa">

Firefox - Light

<img width="1612" alt="Screenshot 2024-11-15 at 9 28 39" src="https://github.com/user-attachments/assets/ef7d28fe-322a-4e64-af2d-00aa9c4da71b">

Firefox - Dark

<img width="1612" alt="Screenshot 2024-11-15 at 9 26 40" src="https://github.com/user-attachments/assets/f51f8843-5d44-4a24-b0a4-58771ee008f6">


Chrome - Light

<img width="1783" alt="Screenshot 2024-11-15 at 9 28 20" src="https://github.com/user-attachments/assets/5119dce3-2695-481e-b1d1-942cecb8054b">


Chrome - Dark

<img width="1783" alt="Screenshot 2024-11-15 at 9 29 28" src="https://github.com/user-attachments/assets/bba0e67b-f50f-4485-b582-d7dc69bdd521">

