### PR TITLE
Revert "Compatibility Mode, the easy part. (#488)"

### DIFF
--- a/sample/animometer/main.ts
+++ b/sample/animometer/main.ts
@@ -3,9 +3,7 @@ import animometerWGSL from './animometer.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/blending/main.ts
+++ b/sample/blending/main.ts
@@ -3,9 +3,7 @@ import { GUI } from 'dat.gui';
 import { quitIfWebGPUNotAvailable } from '../util';
 import texturedQuadWGSL from './texturedQuad.wgsl';
 
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/cameras/main.ts
+++ b/sample/cameras/main.ts
@@ -40,9 +40,7 @@ gui.add(params, 'type', ['arcball', 'WASD']).onChange(() => {
   oldCameraType = newCameraType;
 });
 
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 const context = canvas.getContext('webgpu') as GPUCanvasContext;

--- a/sample/computeBoids/main.ts
+++ b/sample/computeBoids/main.ts
@@ -4,9 +4,7 @@ import updateSpritesWGSL from './updateSprites.wgsl';
 import { GUI } from 'dat.gui';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 quitIfAdapterNotAvailable(adapter);
 
 const hasTimestampQuery = adapter.features.has('timestamp-query');

--- a/sample/fractalCube/main.ts
+++ b/sample/fractalCube/main.ts
@@ -13,9 +13,7 @@ import sampleSelfWGSL from './sampleSelf.frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/gameOfLife/main.ts
+++ b/sample/gameOfLife/main.ts
@@ -5,9 +5,7 @@ import fragWGSL from './frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/helloTriangle/main.ts
+++ b/sample/helloTriangle/main.ts
@@ -3,9 +3,7 @@ import redFragWGSL from '../../shaders/red.frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/helloTriangleMSAA/main.ts
+++ b/sample/helloTriangleMSAA/main.ts
@@ -3,9 +3,7 @@ import redFragWGSL from '../../shaders/red.frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/imageBlur/main.ts
+++ b/sample/imageBlur/main.ts
@@ -8,9 +8,7 @@ const tileDim = 128;
 const batch = [4, 4];
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/instancedCube/main.ts
+++ b/sample/instancedCube/main.ts
@@ -13,9 +13,7 @@ import vertexPositionColorWGSL from '../../shaders/vertexPositionColor.frag.wgsl
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/multipleCanvases/main.ts
+++ b/sample/multipleCanvases/main.ts
@@ -46,9 +46,7 @@ function createVertexAndIndexBuffer(
   };
 }
 
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/normalMap/main.ts
+++ b/sample/normalMap/main.ts
@@ -18,9 +18,7 @@ enum TextureAtlas {
 }
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 const context = canvas.getContext('webgpu') as GPUCanvasContext;

--- a/sample/occlusionQuery/main.ts
+++ b/sample/occlusionQuery/main.ts
@@ -31,9 +31,7 @@ export type TypedArrayConstructor =
 
 const info = document.querySelector('#info');
 
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/points/main.ts
+++ b/sample/points/main.ts
@@ -29,9 +29,7 @@ function createFibonacciSphereVertices({
   return new Float32Array(vertices);
 }
 
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/renderBundles/main.ts
+++ b/sample/renderBundles/main.ts
@@ -14,9 +14,7 @@ interface Renderable {
 }
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/resizeCanvas/main.ts
+++ b/sample/resizeCanvas/main.ts
@@ -3,9 +3,7 @@ import redFragWGSL from '../../shaders/red.frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/resizeObserverHDDPI/main.ts
+++ b/sample/resizeObserverHDDPI/main.ts
@@ -3,9 +3,7 @@ import checkerWGSL from './checker.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/rotatingCube/main.ts
+++ b/sample/rotatingCube/main.ts
@@ -13,9 +13,7 @@ import vertexPositionColorWGSL from '../../shaders/vertexPositionColor.frag.wgsl
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/shadowMapping/main.ts
+++ b/sample/shadowMapping/main.ts
@@ -9,9 +9,7 @@ import { quitIfWebGPUNotAvailable } from '../util';
 const shadowDepthTextureSize = 1024;
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/texturedCube/main.ts
+++ b/sample/texturedCube/main.ts
@@ -13,9 +13,7 @@ import sampleTextureMixColorWGSL from './sampleTextureMixColor.frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/transparentCanvas/main.ts
+++ b/sample/transparentCanvas/main.ts
@@ -13,9 +13,7 @@ import vertexPositionColorWGSL from '../../shaders/vertexPositionColor.frag.wgsl
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/twoCubes/main.ts
+++ b/sample/twoCubes/main.ts
@@ -13,9 +13,7 @@ import vertexPositionColorWGSL from '../../shaders/vertexPositionColor.frag.wgsl
 import { quitIfWebGPUNotAvailable } from '../util';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/videoUploading/main.ts
+++ b/sample/videoUploading/main.ts
@@ -3,9 +3,7 @@ import fullscreenTexturedQuadWGSL from '../../shaders/fullscreenTexturedQuad.wgs
 import sampleExternalTextureWGSL from '../../shaders/sampleExternalTexture.frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 

--- a/sample/volumeRenderingTexture3D/main.ts
+++ b/sample/volumeRenderingTexture3D/main.ts
@@ -18,9 +18,7 @@ gui.add(params, 'rotateCamera', true);
 gui.add(params, 'near', 2.0, 7.0);
 gui.add(params, 'far', 2.0, 7.0);
 
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 const context = canvas.getContext('webgpu') as GPUCanvasContext;

--- a/sample/worker/worker.ts
+++ b/sample/worker/worker.ts
@@ -35,9 +35,7 @@ self.addEventListener('message', (ev) => {
 // to the init() method for all the other samples. The remainder of this file is largely identical
 // to the rotatingCube sample.
 async function init(canvas) {
-  const adapter = await navigator.gpu?.requestAdapter({
-    featureLevel: 'compatibility',
-  });
+  const adapter = await navigator.gpu?.requestAdapter();
   const device = await adapter?.requestDevice();
   quitIfWebGPUNotAvailable(adapter, device);
   const context = canvas.getContext('webgpu');

--- a/sample/workloadSimulator/index.html
+++ b/sample/workloadSimulator/index.html
@@ -586,9 +586,7 @@ async function render(fromRaf, fromPostMessage) {
       try {
         if (deviceRequested) return;
         deviceRequested = true;
-        let adapter = await navigator.gpu.requestAdapter({
-          featureLevel: 'compatibility',
-        });
+        let adapter = await navigator.gpu.requestAdapter();
         featuresAndLimits.textContent = JSON.stringify(
           {
             name: adapter.name,


### PR DESCRIPTION
Revert "Compatibility Mode, the easy part. (#488)"

Chrome Stable with "Enable Unsafe WebGPU" enabled will currently error on these changes, since it requires that
the featureLevel string remain undefined. This will be fixed in the next stable release of Chrome, but it would be
unfortunate to break these samples in the meantime.

This reverts commit 0ce1ef2b244074fd631e85c490670fc0d19d2695.