### PR TITLE
Tweak Particle Sample

### DIFF
--- a/sample/particles/probabilityMap.wgsl
+++ b/sample/particles/probabilityMap.wgsl
@@ -2,16 +2,11 @@ struct UBO {
   width : u32,
 }
 
-struct Buffer {
-  weights : array<f32>,
-}
-
 @binding(0) @group(0) var<uniform> ubo : UBO;
-@binding(1) @group(0) var<storage, read> buf_in : Buffer;
-@binding(2) @group(0) var<storage, read_write> buf_out : Buffer;
+@binding(1) @group(0) var<storage, read> buf_in : array<f32>;
+@binding(2) @group(0) var<storage, read_write> buf_out : array<f32>;
 @binding(3) @group(0) var tex_in : texture_2d<f32>;
 @binding(3) @group(0) var tex_out : texture_storage_2d<rgba8unorm, write>;
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // import_level
@@ -21,9 +16,11 @@ struct Buffer {
 ////////////////////////////////////////////////////////////////////////////////
 @compute @workgroup_size(64)
 fn import_level(@builtin(global_invocation_id) coord : vec3u) {
-  _ = &buf_in;
-  let offset = coord.x + coord.y * ubo.width;
-  buf_out.weights[offset] = textureLoad(tex_in, vec2i(coord.xy), 0).w;
+  _ = &buf_in; // so the bindGroups are similar.
+  if (all(coord.xy < vec2u(textureDimensions(tex_in)))) {
+    let offset = coord.x + coord.y * ubo.width;
+    buf_out[offset] = textureLoad(tex_in, vec2i(coord.xy), 0).w;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -40,13 +37,13 @@ fn export_level(@builtin(global_invocation_id) coord : vec3u) {
     let dst_offset = coord.x    + coord.y    * ubo.width;
     let src_offset = coord.x*2u + coord.y*2u * ubo.width;
 
-    let a = buf_in.weights[src_offset + 0u];
-    let b = buf_in.weights[src_offset + 1u];
-    let c = buf_in.weights[src_offset + 0u + ubo.width];
-    let d = buf_in.weights[src_offset + 1u + ubo.width];
-    let sum = dot(vec4f(a, b, c, d), vec4f(1.0));
+    let a = buf_in[src_offset + 0u];
+    let b = buf_in[src_offset + 1u];
+    let c = buf_in[src_offset + 0u + ubo.width];
+    let d = buf_in[src_offset + 1u + ubo.width];
+    let sum = a + b + c + d;
 
-    buf_out.weights[dst_offset] = sum / 4.0;
+    buf_out[dst_offset] = sum / 4.0;
 
     let probabilities = vec4f(a, a+b, a+b+c, sum) / max(sum, 0.0001);
     textureStore(tex_out, vec2i(coord.xy), probabilities);

--- a/sample/particles/probabilityMap.wgsl
+++ b/sample/particles/probabilityMap.wgsl
@@ -17,10 +17,12 @@ struct UBO {
 @compute @workgroup_size(64)
 fn import_level(@builtin(global_invocation_id) coord : vec3u) {
   _ = &buf_in; // so the bindGroups are similar.
-  if (all(coord.xy < vec2u(textureDimensions(tex_in)))) {
-    let offset = coord.x + coord.y * ubo.width;
-    buf_out[offset] = textureLoad(tex_in, vec2i(coord.xy), 0).w;
+  if (!all(coord.xy < vec2u(textureDimensions(tex_in)))) {
+    return;
   }
+
+  let offset = coord.x + coord.y * ubo.width;
+  buf_out[offset] = textureLoad(tex_in, vec2i(coord.xy), 0).w;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,19 +35,21 @@ fn import_level(@builtin(global_invocation_id) coord : vec3u) {
 ////////////////////////////////////////////////////////////////////////////////
 @compute @workgroup_size(64)
 fn export_level(@builtin(global_invocation_id) coord : vec3u) {
-  if (all(coord.xy < vec2u(textureDimensions(tex_out)))) {
-    let dst_offset = coord.x    + coord.y    * ubo.width;
-    let src_offset = coord.x*2u + coord.y*2u * ubo.width;
-
-    let a = buf_in[src_offset + 0u];
-    let b = buf_in[src_offset + 1u];
-    let c = buf_in[src_offset + 0u + ubo.width];
-    let d = buf_in[src_offset + 1u + ubo.width];
-    let sum = a + b + c + d;
-
-    buf_out[dst_offset] = sum / 4.0;
-
-    let probabilities = vec4f(a, a+b, a+b+c, sum) / max(sum, 0.0001);
-    textureStore(tex_out, vec2i(coord.xy), probabilities);
+  if (!all(coord.xy < vec2u(textureDimensions(tex_out)))) {
+    return;
   }
+
+  let dst_offset = coord.x    + coord.y    * ubo.width;
+  let src_offset = coord.x*2u + coord.y*2u * ubo.width;
+
+  let a = buf_in[src_offset + 0u];
+  let b = buf_in[src_offset + 1u];
+  let c = buf_in[src_offset + 0u + ubo.width];
+  let d = buf_in[src_offset + 1u + ubo.width];
+  let sum = a + b + c + d;
+
+  buf_out[dst_offset] = sum / 4.0;
+
+  let probabilities = vec4f(a, a+b, a+b+c, sum) / max(sum, 0.0001);
+  textureStore(tex_out, vec2i(coord.xy), probabilities);
 }


### PR DESCRIPTION
I was investigating why this sample didn't work on compat mode in Chrome.

I found 1 issue in the code which is the shader that makes the probability map only worked if the source image is was a multiple of 64 pixels wide. This was because it was not conditionally skipping out of bounds pixels and so those pixels would end up overwriting other results.

This issue does not come up in the sample but if you change the image to some image that is not a multiple of 64 pixels across the issue comes up.

In debugging why GL was failing one my paths was to make a 16x16 pixel `F` using the canvas 2D api and passing that in so that I can print out all the data. With that I ran into this issue.

So, I added the skipping. Thank's to Peter McNeeley for finding that issue.

While pursing the code I find somethings I thought maybe should be refactored?

* Calculating the number of mip level was done in a loop.

  Changed it to just math.

* Moving some calculations to use properties on the texture.

  I can revert these changes. They were useful when I switched the source image since then the code didn't depend on variables that were no longer available.

* Getting rid of `struct Buffer`

  I can revert these changes. I get the impression that this was a limitation of an earlier version of WGSL. It seems more confusing to me personally have have a struct with a single array member in it than to just have the array.

* Simpler math

  I can revert this but, changed `sum = dot(vec4f(a, b, c, d), vec4f(1.0))` to `sum = a + b + c + d`.

Note that, even with the change for the first pass, the code only works for square power-of-2 images. Both the probability generation and the usage of that data require each mip level to be exactly 1/2 the size of the previous level so added some asserts.