### PR TITLE
Add in viewDimension for cube-array fallback

### DIFF
--- a/sample/generateMipmap/main.ts
+++ b/sample/generateMipmap/main.ts
@@ -120,13 +120,14 @@ if (
     size: [256, 256, 6],
     mipLevelCount: 9,
     format: 'rgba8unorm',
+    textureBindingViewDimension: 'cube',
     usage:
       GPUTextureUsage.TEXTURE_BINDING |
       GPUTextureUsage.COPY_DST |
       GPUTextureUsage.RENDER_ATTACHMENT,
   });
   putDataInTextureCubeFallback(device, texture);
-  generateMips(device, texture);
+  generateMips(device, texture, 'cube');
   textures.push({ texture, viewDimension: 'cube' });
   document.querySelector('#cube-array').textContent = 'cube(fallback)';
 }


### PR DESCRIPTION
If we're in compatbility mode we use a cube instead of cube-array for the 4th cube. I forgot to pass in the viewDimesion to both the texture creation and
generateMips. Added.