### PR TITLE
Show error dialog on unhandled rejection and uncaught exception

### DIFF
--- a/sample/util.ts
+++ b/sample/util.ts
@@ -1,3 +1,14 @@
+// Show an error dialog if there's any uncaught exception or promise rejection.
+// This gets set up on all pages that include util.ts.
+window.addEventListener('unhandledrejection', (ev) => {
+  fail(`unhandled promise rejection, please report a bug!
+  https://github.com/webgpu/webgpu-samples/issues/new\n${ev.reason}`);
+});
+window.addEventListener('error', (ev) => {
+  fail(`uncaught exception, please report a bug!
+  https://github.com/webgpu/webgpu-samples/issues/new\n${ev.error}`);
+});
+
 /** Shows an error dialog if getting an adapter wasn't successful. */
 export function quitIfAdapterNotAvailable(
   adapter: GPUAdapter | null


### PR DESCRIPTION
These errors aren't supposed to happen in the samples, but if they do, we want them to be visible. Otherwise they can only be seen in the dev tools console, and sometimes you can't tell that the sample is misbehaving, e.g.:
https://github.com/webgpu/webgpu-samples/pull/501#discussion_r2049424888

![image](https://github.com/user-attachments/assets/df47dec9-c5c7-49d5-8a9c-831c9c1919a6)
