### PR TITLE
Make server match github for content-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "node build/tools/build.js",
     "start": "node build/tools/serve.js",
     "serve": "node build/tools/serve.js",
-    "server": "servez out",
+    "server": "servez --no-unity-hack out",
     "watch": "rollup -c -w",
     "export": "npm run build"
   },


### PR DESCRIPTION
Unity assumes the server is configured so that when it asks for a file that ends in .gz the content-type is set to gzip. Servez makes that the default.

Turning off that feature makes it match github pages which does do this.

This repos the issue mentioned in https://github.com/webgpu/webgpu-samples/issues/504 locally. Separately we can decide how to fix that issue.