### PR TITLE
Make `fetch`/`DecompressionStream` usage more canonical.

### DIFF
--- a/sample/volumeRenderingTexture3D/main.ts
+++ b/sample/volumeRenderingTexture3D/main.ts
@@ -158,13 +158,10 @@ async function createVolumeTexture(format: GPUTextureFormat) {
   });
 
   const response = await fetch(dataPath);
-  const compressedBlob = await response.blob();
 
   // Decompress the data using DecompressionStream for gzip format
   const decompressionStream = new DecompressionStream('gzip');
-  const decompressedStream = compressedBlob
-    .stream()
-    .pipeThrough(decompressionStream);
+  const decompressedStream = response.body.pipeThrough(decompressionStream);
   const decompressedArrayBuffer = await new Response(
     decompressedStream
   ).arrayBuffer();


### PR DESCRIPTION
The `body` property of a `Response` from `fetch` is a stream.