### PR TITLE
Revert "Show error dialog on unhandled rejection and uncaught exception"

### DIFF
--- a/sample/util.ts
+++ b/sample/util.ts
@@ -1,14 +1,3 @@
-// Show an error dialog if there's any uncaught exception or promise rejection.
-// This gets set up on all pages that include util.ts.
-window.addEventListener('unhandledrejection', (ev) => {
-  fail(`unhandled promise rejection, please report a bug!
-  https://github.com/webgpu/webgpu-samples/issues/new\n${ev.reason}`);
-});
-window.addEventListener('error', (ev) => {
-  fail(`uncaught exception, please report a bug!
-  https://github.com/webgpu/webgpu-samples/issues/new\n${ev.error}`);
-});
-
 /** Shows an error dialog if getting an adapter wasn't successful. */
 export function quitIfAdapterNotAvailable(
   adapter: GPUAdapter | null


### PR DESCRIPTION
Reverts webgpu/webgpu-samples#502, broken on worker sample

Fixes #508, will make sure I don't break it again when relanding