### PR TITLE
Roll @webgpu/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/showdown": "^2.0.6",
         "@types/stats.js": "^0.17.3",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
-        "@webgpu/types": "^0.1.53",
+        "@webgpu/types": "^0.1.60",
         "chokidar": "^4.0.3",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^8.10.0",
@@ -1092,9 +1092,9 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.53",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.53.tgz",
-      "integrity": "sha512-x+BLw/opaz9LiVyrMsP75nO1Rg0QfrACUYIbVSfGwY/w0DiWIPYYrpte6us//KZXinxFAOJl0+C17L1Vi2vmDw==",
+      "version": "0.1.60",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.60.tgz",
+      "integrity": "sha512-8B/tdfRFKdrnejqmvq95ogp8tf52oZ51p3f4QD5m5Paey/qlX4Rhhy5Y8tgFMi7Ms70HzcMMw3EQjH/jdhTwlA==",
       "dev": true
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/showdown": "^2.0.6",
     "@types/stats.js": "^0.17.3",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@webgpu/types": "^0.1.53",
+    "@webgpu/types": "^0.1.60",
     "chokidar": "^4.0.3",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^8.10.0",


### PR DESCRIPTION
We don't currently strictly enforce types but this improves some types that show up in IDEs.