### PR TITLE
Prevent image flash when switching between texture formats

### DIFF
--- a/sample/volumeRenderingTexture3D/main.ts
+++ b/sample/volumeRenderingTexture3D/main.ts
@@ -130,10 +130,11 @@ const uniformBuffer = device.createBuffer({
 });
 
 let volumeTexture: GPUTexture | null = null;
+let isVolumeTextureReady = false;
 
 // Fetch the image and upload it into a GPUTexture.
 async function createVolumeTexture(format: GPUTextureFormat) {
-  volumeTexture = null;
+  isVolumeTextureReady = false;
 
   const { blockLength, bytesPerBlock, dataPath, feature } = brainImages[format];
   const width = 180;
@@ -172,6 +173,8 @@ async function createVolumeTexture(format: GPUTextureFormat) {
     { bytesPerRow: bytesPerRow, rowsPerImage: blocksHigh },
     [width, height, depth]
   );
+  await device.queue.onSubmittedWorkDone();
+  isVolumeTextureReady = true;
 }
 
 await createVolumeTexture(params.textureFormat);
@@ -260,7 +263,7 @@ function frame() {
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
-  if (volumeTexture) {
+  if (isVolumeTextureReady) {
     bindGroupDescriptor.entries[2].resource = volumeTexture.createView();
     const uniformBindGroup = device.createBindGroup(bindGroupDescriptor);
     passEncoder.setPipeline(pipeline);


### PR DESCRIPTION
An image flash occurs when switching between texture formats. I believe it happens because writeTexture may not be complete causing the canvas to use incomplete texture data.
