### PR TITLE
Fix blur artifacts

### DIFF
--- a/sample/imageBlur/blur.wgsl
+++ b/sample/imageBlur/blur.wgsl
@@ -50,7 +50,7 @@ fn main(
       tile[r][4 * LocalInvocationID.x + u32(c)] = textureSampleLevel(
         inputTex,
         samp,
-        (vec2f(loadIndex) + vec2f(0.25, 0.25)) / vec2f(dims),
+        (vec2f(loadIndex) + vec2f(0.5, 0.5)) / vec2f(dims),
         0.0
       ).rgb;
     }

--- a/sample/imageBlur/main.ts
+++ b/sample/imageBlur/main.ts
@@ -220,11 +220,11 @@ const settings = {
 
 let blockDim: number;
 const updateSettings = () => {
-  blockDim = tileDim - (settings.filterSize - 1);
+  blockDim = tileDim - settings.filterSize;
   device.queue.writeBuffer(
     blurParamsBuffer,
     0,
-    new Uint32Array([settings.filterSize, blockDim])
+    new Uint32Array([settings.filterSize + 1, blockDim])
   );
 };
 const gui = new GUI();


### PR DESCRIPTION
Following https://github.com/webgpu/webgpu-samples/pull/181/files#r889367976 suggestion, this PR fixes blur artifacts (around the eye most notably) that happen with `filterSize: 2` and `iterations: 10`.

<img src=https://github.com/user-attachments/assets/e47dc3f7-82cd-4b33-8afe-6df365c6ae60 width=49%>
<img src=https://github.com/user-attachments/assets/7487e278-216f-4884-af92-15e14c9c2418 width=49%>
<i> Before (left) / After (right)</i>
