### PR TITLE
Add WebGPUCompatibilityMode origin trial tokens

### DIFF
--- a/sample/a-buffer/index.html
+++ b/sample/a-buffer/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: a-buffer</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/animometer/index.html
+++ b/sample/animometer/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: animometer</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/bitonicSort/index.html
+++ b/sample/bitonicSort/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: bitonicSort</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/blending/index.html
+++ b/sample/blending/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: blending</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/cameras/index.html
+++ b/sample/cameras/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: cameras</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/computeBoids/index.html
+++ b/sample/computeBoids/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: computeBoids</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/cornell/index.html
+++ b/sample/cornell/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: cornell</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/cubemap/index.html
+++ b/sample/cubemap/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: cubemap</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/deferredRendering/index.html
+++ b/sample/deferredRendering/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: deferredRendering</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/fractalCube/index.html
+++ b/sample/fractalCube/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: fractalCube</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/gameOfLife/index.html
+++ b/sample/gameOfLife/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: gameOfLife</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/generateMipmap/index.html
+++ b/sample/generateMipmap/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: generateMipmap</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/helloTriangle/index.html
+++ b/sample/helloTriangle/index.html
@@ -3,6 +3,16 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <title>webgpu-samples: helloTriangle</title>
     <style>
       :root {

--- a/sample/helloTriangleMSAA/index.html
+++ b/sample/helloTriangleMSAA/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: helloTriangleMSAA</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/imageBlur/index.html
+++ b/sample/imageBlur/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: imageBlur</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/instancedCube/index.html
+++ b/sample/instancedCube/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: instancedCube</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/multipleCanvases/index.html
+++ b/sample/multipleCanvases/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: multipleCanvases</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/normalMap/index.html
+++ b/sample/normalMap/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: normalMap</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/occlusionQuery/index.html
+++ b/sample/occlusionQuery/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: occlusionQuery</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/particles/index.html
+++ b/sample/particles/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: particles (HDR)</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/points/index.html
+++ b/sample/points/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: points</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/renderBundles/index.html
+++ b/sample/renderBundles/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: renderBundles</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/resizeCanvas/index.html
+++ b/sample/resizeCanvas/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: resizeCanvas</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/resizeObserverHDDPI/index.html
+++ b/sample/resizeObserverHDDPI/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: resizeObserverHDDPI</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/reversedZ/index.html
+++ b/sample/reversedZ/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: reversedZ</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/rotatingCube/index.html
+++ b/sample/rotatingCube/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: rotatingCube</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/samplerParameters/index.html
+++ b/sample/samplerParameters/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: samplerParameters</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/shadowMapping/index.html
+++ b/sample/shadowMapping/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: shadowMapping</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/skinnedMesh/index.html
+++ b/sample/skinnedMesh/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: skinnedMesh</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/stencilMask/index.html
+++ b/sample/stencilMask/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: stencil mask</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/textRenderingMsdf/index.html
+++ b/sample/textRenderingMsdf/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: textRenderingMsdf</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/texturedCube/index.html
+++ b/sample/texturedCube/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: texturedCube</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/timestampQuery/index.html
+++ b/sample/timestampQuery/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: timestampQuery</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/transparentCanvas/index.html
+++ b/sample/transparentCanvas/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: transparentCanvas</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/twoCubes/index.html
+++ b/sample/twoCubes/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: twoCubes</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/videoUploading/index.html
+++ b/sample/videoUploading/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: videoUploading</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/volumeRenderingTexture3D/index.html
+++ b/sample/volumeRenderingTexture3D/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: volumeRenderingTexture3D</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/wireframe/index.html
+++ b/sample/wireframe/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: wireframe</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/worker/index.html
+++ b/sample/worker/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>webgpu-samples: worker</title>
+    <!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
+    <!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+    />
     <style>
       :root {
         color-scheme: light dark;

--- a/sample/workloadSimulator/index.html
+++ b/sample/workloadSimulator/index.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html><meta charset="utf-8">
 <meta name=viewport content="width=900">
+<!-- WebGPUCompatibilityMode origin token for https://webgpu.github.io expiring April 21, 2026 -->
+<meta
+  http-equiv="origin-trial"
+  content="Aktu7041jFm00ls336/bRinubASRzg1tPs4wxXOZkF1uP0LaIURinGC7ti0Vf352Q9OKFL1siRfpptLjNIKpKQcAAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+/>
+<!-- WebGPUCompatibilityMode origin token for http://localhost:8080 expiring April 21, 2026 -->
+<meta
+  http-equiv="origin-trial"
+  content="AqW27Ayelg5vbcAaYcweU+sLjZq5r6idHCWU4MJgnkP1YBgmOMqazdGuakSnGylTkyA/bRHkCJZFdfYjFlylOgAAAABaeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVQ29tcGF0aWJpbGl0eU1vZGUiLCJleHBpcnkiOjE3NzY3Mjk2MDB9"
+/>
 <title>Web graphics workload simulator</title>
 <style>
 body {


### PR DESCRIPTION
This PR adds tokens for the [WebGPU compatibility mode origin trial](https://developer.chrome.com/origintrials/#/view_trial/1489002626799370241):
- one for https://webgpu.github.io (production URL) expiring April 21, 2026 
- one for http://localhost:8080 (development URL) expiring April 21, 2026

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/b590936b-3dea-4e20-b04b-168651ce3a6e" />
