### PR TITLE
Use texture shorthands instead of view when possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/showdown": "^2.0.6",
         "@types/stats.js": "^0.17.4",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
-        "@webgpu/types": "^0.1.61",
+        "@webgpu/types": "^0.1.64",
         "chokidar": "^4.0.3",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^8.10.0",
@@ -1103,10 +1103,11 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.61",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.61.tgz",
-      "integrity": "sha512-w2HbBvH+qO19SB5pJOJFKs533CdZqxl3fcGonqL321VHkW7W/iBo6H8bjDy6pr/+pbMwIu5dnuaAxH7NxBqUrQ==",
-      "dev": true
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/accepts": {
       "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/showdown": "^2.0.6",
     "@types/stats.js": "^0.17.4",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@webgpu/types": "^0.1.61",
+    "@webgpu/types": "^0.1.64",
     "chokidar": "^4.0.3",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^8.10.0",

--- a/sample/a-buffer/main.ts
+++ b/sample/a-buffer/main.ts
@@ -365,10 +365,6 @@ const configure = () => {
     label: 'depthTexture',
   });
 
-  const depthTextureView = depthTexture.createView({
-    label: 'depthTextureView',
-  });
-
   // Determines how much memory is allocated to store linked-list elements
   const averageLayersPerFragment = 4;
 
@@ -466,7 +462,7 @@ const configure = () => {
       },
       {
         binding: 3,
-        resource: depthTextureView,
+        resource: depthTexture,
       },
       {
         binding: 4,
@@ -510,7 +506,7 @@ const configure = () => {
     ],
   });
 
-  opaquePassDescriptor.depthStencilAttachment.view = depthTextureView;
+  opaquePassDescriptor.depthStencilAttachment.view = depthTexture;
 
   // Rotates the camera around the origin based on time.
   function getCameraViewProjMatrix() {
@@ -552,10 +548,10 @@ const configure = () => {
     }
 
     const commandEncoder = device.createCommandEncoder();
-    const textureView = context.getCurrentTexture().createView();
+    const canvasTexture = context.getCurrentTexture();
 
     // Draw the opaque objects
-    opaquePassDescriptor.colorAttachments[0].view = textureView;
+    opaquePassDescriptor.colorAttachments[0].view = canvasTexture;
     const opaquePassEncoder =
       commandEncoder.beginRenderPass(opaquePassDescriptor);
     opaquePassEncoder.setPipeline(opaquePipeline);
@@ -577,7 +573,7 @@ const configure = () => {
         slice * sliceHeight;
 
       // Draw the translucent objects
-      translucentPassDescriptor.colorAttachments[0].view = textureView;
+      translucentPassDescriptor.colorAttachments[0].view = canvasTexture;
       const translucentPassEncoder = commandEncoder.beginRenderPass(
         translucentPassDescriptor
       );
@@ -600,7 +596,7 @@ const configure = () => {
       translucentPassEncoder.end();
 
       // Composite the opaque and translucent objects
-      compositePassDescriptor.colorAttachments[0].view = textureView;
+      compositePassDescriptor.colorAttachments[0].view = canvasTexture;
       const compositePassEncoder = commandEncoder.beginRenderPass(
         compositePassDescriptor
       );

--- a/sample/animometer/main.ts
+++ b/sample/animometer/main.ts
@@ -298,9 +298,7 @@ function configure() {
     uniformTime[0] = (timestamp - startTime) / 1000;
     device.queue.writeBuffer(uniformBuffer, timeOffset, uniformTime.buffer);
 
-    renderPassDescriptor.colorAttachments[0].view = context
-      .getCurrentTexture()
-      .createView();
+    renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
     const commandEncoder = device.createCommandEncoder();
     const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/bitonicSort/main.ts
+++ b/sample/bitonicSort/main.ts
@@ -717,9 +717,8 @@ SampleInitFactoryWebGPU(
 
       device.queue.writeBuffer(computeUniformsBuffer, 8, stepDetails);
 
-      renderPassDescriptor.colorAttachments[0].view = context
-        .getCurrentTexture()
-        .createView();
+      renderPassDescriptor.colorAttachments[0].view =
+        context.getCurrentTexture();
 
       const commandEncoder = device.createCommandEncoder();
       bitonicDisplayRenderer.startRun(commandEncoder, {

--- a/sample/blending/main.ts
+++ b/sample/blending/main.ts
@@ -193,7 +193,7 @@ const srcBindGroupUnpremultipliedAlpha = device.createBindGroup({
   layout: bindGroupLayout,
   entries: [
     { binding: 0, resource: sampler },
-    { binding: 1, resource: srcTextureUnpremultipliedAlpha.createView() },
+    { binding: 1, resource: srcTextureUnpremultipliedAlpha },
     { binding: 2, resource: { buffer: srcUniform.buffer } },
   ],
 });
@@ -202,7 +202,7 @@ const dstBindGroupUnpremultipliedAlpha = device.createBindGroup({
   layout: bindGroupLayout,
   entries: [
     { binding: 0, resource: sampler },
-    { binding: 1, resource: dstTextureUnpremultipliedAlpha.createView() },
+    { binding: 1, resource: dstTextureUnpremultipliedAlpha },
     { binding: 2, resource: { buffer: dstUniform.buffer } },
   ],
 });
@@ -211,7 +211,7 @@ const srcBindGroupPremultipliedAlpha = device.createBindGroup({
   layout: bindGroupLayout,
   entries: [
     { binding: 0, resource: sampler },
-    { binding: 1, resource: srcTexturePremultipliedAlpha.createView() },
+    { binding: 1, resource: srcTexturePremultipliedAlpha },
     { binding: 2, resource: { buffer: srcUniform.buffer } },
   ],
 });
@@ -220,7 +220,7 @@ const dstBindGroupPremultipliedAlpha = device.createBindGroup({
   layout: bindGroupLayout,
   entries: [
     { binding: 0, resource: sampler },
-    { binding: 1, resource: dstTexturePremultipliedAlpha.createView() },
+    { binding: 1, resource: dstTexturePremultipliedAlpha },
     { binding: 2, resource: { buffer: dstUniform.buffer } },
   ],
 });
@@ -518,7 +518,7 @@ function render() {
   const canvasTexture = context.getCurrentTexture();
   // Get the current texture from the canvas context and
   // set it as the texture to render to.
-  renderPassDescriptor.colorAttachments[0].view = canvasTexture.createView();
+  renderPassDescriptor.colorAttachments[0].view = canvasTexture;
 
   // Apply the clearValue, pre-multiplying or not it based on the settings.
   {

--- a/sample/cameras/main.ts
+++ b/sample/cameras/main.ts
@@ -167,7 +167,7 @@ const uniformBindGroup = device.createBindGroup({
     },
     {
       binding: 2,
-      resource: cubeTexture.createView(),
+      resource: cubeTexture,
     },
   ],
 });
@@ -183,7 +183,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -217,9 +217,7 @@ function frame() {
     modelViewProjection.byteOffset,
     modelViewProjection.byteLength
   );
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/computeBoids/main.ts
+++ b/sample/computeBoids/main.ts
@@ -259,9 +259,7 @@ let computePassDurationSum = 0;
 let renderPassDurationSum = 0;
 let timerSamples = 0;
 function frame() {
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   {

--- a/sample/cornell/radiosity.ts
+++ b/sample/cornell/radiosity.ts
@@ -119,7 +119,7 @@ export default class Radiosity {
         {
           // lightmap
           binding: 1,
-          resource: this.lightmap.createView(),
+          resource: this.lightmap,
         },
         {
           // radiosity_uniforms

--- a/sample/cornell/rasterizer.ts
+++ b/sample/cornell/rasterizer.ts
@@ -35,14 +35,14 @@ export default class Rasterizer {
       label: 'RasterizerRenderer.renderPassDescriptor',
       colorAttachments: [
         {
-          view: framebuffer.createView(),
+          view: framebuffer,
           clearValue: [0.1, 0.2, 0.3, 1],
           loadOp: 'clear',
           storeOp: 'store',
         },
       ],
       depthStencilAttachment: {
-        view: depthTexture.createView(),
+        view: depthTexture,
         depthClearValue: 1.0,
         depthLoadOp: 'clear',
         depthStoreOp: 'store',
@@ -74,7 +74,7 @@ export default class Rasterizer {
         {
           // lightmap
           binding: 0,
-          resource: radiosity.lightmap.createView(),
+          resource: radiosity.lightmap,
         },
         {
           // sampler

--- a/sample/cornell/raytracer.ts
+++ b/sample/cornell/raytracer.ts
@@ -57,7 +57,7 @@ export default class Raytracer {
       entries: [
         {
           binding: 0,
-          resource: radiosity.lightmap.createView(),
+          resource: radiosity.lightmap,
         },
         {
           binding: 1,
@@ -71,7 +71,7 @@ export default class Raytracer {
         },
         {
           binding: 2,
-          resource: framebuffer.createView(),
+          resource: framebuffer,
         },
       ],
     });

--- a/sample/cornell/tonemapper.ts
+++ b/sample/cornell/tonemapper.ts
@@ -51,12 +51,12 @@ export default class Tonemapper {
         {
           // input
           binding: 0,
-          resource: input.createView(),
+          resource: input,
         },
         {
           // output
           binding: 1,
-          resource: output.createView(),
+          resource: output,
         },
       ],
     });

--- a/sample/cubemap/main.ts
+++ b/sample/cubemap/main.ts
@@ -186,7 +186,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -234,9 +234,7 @@ function frame() {
     modelViewProjectionMatrix.byteLength
   );
 
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/deferredRendering/main.ts
+++ b/sample/deferredRendering/main.ts
@@ -87,10 +87,10 @@ const depthTexture = device.createTexture({
   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
 });
 
-const gBufferTextureViews = [
-  gBufferTexture2DFloat16.createView(),
-  gBufferTextureAlbedo.createView(),
-  depthTexture.createView(),
+const gBufferTextures = [
+  gBufferTexture2DFloat16,
+  gBufferTextureAlbedo,
+  depthTexture,
 ];
 
 const vertexBuffers: Iterable<GPUVertexBufferLayout> = [
@@ -257,14 +257,14 @@ const deferredRenderPipeline = device.createRenderPipeline({
 const writeGBufferPassDescriptor: GPURenderPassDescriptor = {
   colorAttachments: [
     {
-      view: gBufferTextureViews[0],
+      view: gBufferTextures[0],
 
       clearValue: [0.0, 0.0, 1.0, 1.0],
       loadOp: 'clear',
       storeOp: 'store',
     },
     {
-      view: gBufferTextureViews[1],
+      view: gBufferTextures[1],
 
       clearValue: [0, 0, 0, 1],
       loadOp: 'clear',
@@ -272,7 +272,7 @@ const writeGBufferPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -354,15 +354,15 @@ const gBufferTexturesBindGroup = device.createBindGroup({
   entries: [
     {
       binding: 0,
-      resource: gBufferTextureViews[0],
+      resource: gBufferTextures[0],
     },
     {
       binding: 1,
-      resource: gBufferTextureViews[1],
+      resource: gBufferTextures[1],
     },
     {
       binding: 2,
-      resource: gBufferTextureViews[2],
+      resource: gBufferTextures[2],
     },
   ],
 });
@@ -551,9 +551,8 @@ function frame() {
       // Left: depth
       // Middle: normal
       // Right: albedo (use uv to mimic a checkerboard texture)
-      textureQuadPassDescriptor.colorAttachments[0].view = context
-        .getCurrentTexture()
-        .createView();
+      textureQuadPassDescriptor.colorAttachments[0].view =
+        context.getCurrentTexture();
       const debugViewPass = commandEncoder.beginRenderPass(
         textureQuadPassDescriptor
       );
@@ -563,9 +562,8 @@ function frame() {
       debugViewPass.end();
     } else {
       // Deferred rendering
-      textureQuadPassDescriptor.colorAttachments[0].view = context
-        .getCurrentTexture()
-        .createView();
+      textureQuadPassDescriptor.colorAttachments[0].view =
+        context.getCurrentTexture();
       const deferredRenderingPass = commandEncoder.beginRenderPass(
         textureQuadPassDescriptor
       );

--- a/sample/fractalCube/main.ts
+++ b/sample/fractalCube/main.ts
@@ -139,7 +139,7 @@ const uniformBindGroup = device.createBindGroup({
     },
     {
       binding: 2,
-      resource: cubeTexture.createView(),
+      resource: cubeTexture,
     },
   ],
 });
@@ -155,7 +155,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -194,8 +194,7 @@ function frame() {
   );
 
   const swapChainTexture = context.getCurrentTexture();
-  // prettier-ignore
-  renderPassDescriptor.colorAttachments[0].view = swapChainTexture.createView();
+  renderPassDescriptor.colorAttachments[0].view = swapChainTexture;
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/gameOfLife/main.ts
+++ b/sample/gameOfLife/main.ts
@@ -221,11 +221,10 @@ function resetGameData() {
 
   loopTimes = 0;
   render = () => {
-    const view = context.getCurrentTexture().createView();
     const renderPass: GPURenderPassDescriptor = {
       colorAttachments: [
         {
-          view,
+          view: context.getCurrentTexture(),
           loadOp: 'clear',
           storeOp: 'store',
         },

--- a/sample/generateMipmap/main.ts
+++ b/sample/generateMipmap/main.ts
@@ -225,7 +225,7 @@ function render(time: number) {
   time *= 0.001;
 
   const canvasTexture = context.getCurrentTexture();
-  renderPassDescriptor.colorAttachments[0].view = canvasTexture.createView();
+  renderPassDescriptor.colorAttachments[0].view = canvasTexture;
 
   const aspect = canvas.clientWidth / canvas.clientHeight;
   const projection = mat4.perspective((90 * Math.PI) / 180, aspect, 0.1, 20);

--- a/sample/helloTriangle/main.ts
+++ b/sample/helloTriangle/main.ts
@@ -45,12 +45,12 @@ const pipeline = device.createRenderPipeline({
 
 function frame() {
   const commandEncoder = device.createCommandEncoder();
-  const textureView = context.getCurrentTexture().createView();
+  const canvasTexture = context.getCurrentTexture();
 
   const renderPassDescriptor: GPURenderPassDescriptor = {
     colorAttachments: [
       {
-        view: textureView,
+        view: canvasTexture,
         clearValue: [0, 0, 0, 0], // Clear to transparent
         loadOp: 'clear',
         storeOp: 'store',

--- a/sample/helloTriangleMSAA/main.ts
+++ b/sample/helloTriangleMSAA/main.ts
@@ -54,7 +54,6 @@ const texture = device.createTexture({
   format: presentationFormat,
   usage: GPUTextureUsage.RENDER_ATTACHMENT,
 });
-const view = texture.createView();
 
 function frame() {
   const commandEncoder = device.createCommandEncoder();
@@ -62,8 +61,8 @@ function frame() {
   const renderPassDescriptor: GPURenderPassDescriptor = {
     colorAttachments: [
       {
-        view,
-        resolveTarget: context.getCurrentTexture().createView(),
+        view: texture,
+        resolveTarget: context.getCurrentTexture(),
         clearValue: [0, 0, 0, 0], // Clear to transparent
         loadOp: 'clear',
         storeOp: 'discard',

--- a/sample/imageBlur/main.ts
+++ b/sample/imageBlur/main.ts
@@ -144,11 +144,11 @@ const computeBindGroup0 = device.createBindGroup({
   entries: [
     {
       binding: 1,
-      resource: imageTexture.createView(),
+      resource: imageTexture,
     },
     {
       binding: 2,
-      resource: textures[0].createView(),
+      resource: textures[0],
     },
     {
       binding: 3,
@@ -164,11 +164,11 @@ const computeBindGroup1 = device.createBindGroup({
   entries: [
     {
       binding: 1,
-      resource: textures[0].createView(),
+      resource: textures[0],
     },
     {
       binding: 2,
-      resource: textures[1].createView(),
+      resource: textures[1],
     },
     {
       binding: 3,
@@ -184,11 +184,11 @@ const computeBindGroup2 = device.createBindGroup({
   entries: [
     {
       binding: 1,
-      resource: textures[1].createView(),
+      resource: textures[1],
     },
     {
       binding: 2,
-      resource: textures[0].createView(),
+      resource: textures[0],
     },
     {
       binding: 3,
@@ -208,7 +208,7 @@ const showResultBindGroup = device.createBindGroup({
     },
     {
       binding: 1,
-      resource: textures[1].createView(),
+      resource: textures[1],
     },
   ],
 });
@@ -271,7 +271,7 @@ function frame() {
   const passEncoder = commandEncoder.beginRenderPass({
     colorAttachments: [
       {
-        view: context.getCurrentTexture().createView(),
+        view: context.getCurrentTexture(),
         clearValue: [0, 0, 0, 1],
         loadOp: 'clear',
         storeOp: 'store',

--- a/sample/instancedCube/main.ts
+++ b/sample/instancedCube/main.ts
@@ -194,7 +194,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -213,9 +213,7 @@ function frame() {
     mvpMatricesData.byteLength
   );
 
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/multipleCanvases/main.ts
+++ b/sample/multipleCanvases/main.ts
@@ -305,7 +305,7 @@ function render(time: number) {
     // Get the current texture from the canvas context and
     // set it as the texture to render to.
     const canvasTexture = context.getCurrentTexture();
-    renderPassDescriptor.colorAttachments[0].view = canvasTexture.createView();
+    renderPassDescriptor.colorAttachments[0].view = canvasTexture;
     renderPassDescriptor.colorAttachments[0].clearValue = clearValue;
 
     // If we don't have a depth texture OR if its size is different
@@ -325,8 +325,7 @@ function render(time: number) {
       });
       canvasInfo.depthTexture = depthTexture;
     }
-    renderPassDescriptor.depthStencilAttachment.view =
-      depthTexture.createView();
+    renderPassDescriptor.depthStencilAttachment.view = depthTexture;
 
     const fov = (60 * Math.PI) / 180;
     const aspect = canvas.clientWidth / canvas.clientHeight;

--- a/sample/normalMap/main.ts
+++ b/sample/normalMap/main.ts
@@ -166,7 +166,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -206,23 +206,13 @@ const surfaceBGDescriptor = createBindGroupDescriptor(
   ],
   // Multiple bindgroups that accord to the layout defined above
   [
+    [sampler, woodAlbedoTexture, spiralNormalTexture, spiralHeightTexture],
+    [sampler, woodAlbedoTexture, toyboxNormalTexture, toyboxHeightTexture],
     [
       sampler,
-      woodAlbedoTexture.createView(),
-      spiralNormalTexture.createView(),
-      spiralHeightTexture.createView(),
-    ],
-    [
-      sampler,
-      woodAlbedoTexture.createView(),
-      toyboxNormalTexture.createView(),
-      toyboxHeightTexture.createView(),
-    ],
-    [
-      sampler,
-      brickwallAlbedoTexture.createView(),
-      brickwallNormalTexture.createView(),
-      brickwallHeightTexture.createView(),
+      brickwallAlbedoTexture,
+      brickwallNormalTexture,
+      brickwallHeightTexture,
     ],
   ],
   'Surface',
@@ -360,9 +350,7 @@ function frame() {
   mapInfoView.setFloat32(24, settings.depthLayers, true);
   device.queue.writeBuffer(mapInfoBuffer, 0, mapInfoArray);
 
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/occlusionQuery/main.ts
+++ b/sample/occlusionQuery/main.ts
@@ -274,8 +274,8 @@ function render(now: number) {
   }
 
   const colorTexture = context.getCurrentTexture();
-  renderPassDescriptor.colorAttachments[0].view = colorTexture.createView();
-  renderPassDescriptor.depthStencilAttachment.view = depthTexture.createView();
+  renderPassDescriptor.colorAttachments[0].view = colorTexture;
+  renderPassDescriptor.depthStencilAttachment.view = depthTexture;
 
   const encoder = device.createCommandEncoder();
   const pass = encoder.beginRenderPass(renderPassDescriptor);

--- a/sample/particles/main.ts
+++ b/sample/particles/main.ts
@@ -158,7 +158,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -386,7 +386,7 @@ const computeBindGroup = device.createBindGroup({
     },
     {
       binding: 2,
-      resource: texture.createView(),
+      resource: texture,
     },
   ],
 });
@@ -439,7 +439,7 @@ function frame() {
   );
   const swapChainTexture = context.getCurrentTexture();
   // prettier-ignore
-  renderPassDescriptor.colorAttachments[0].view = swapChainTexture.createView();
+  renderPassDescriptor.colorAttachments[0].view = swapChainTexture;
 
   const commandEncoder = device.createCommandEncoder();
   {

--- a/sample/points/main.ts
+++ b/sample/points/main.ts
@@ -194,7 +194,7 @@ const bindGroup = device.createBindGroup({
   entries: [
     { binding: 0, resource: { buffer: uniformBuffer } },
     { binding: 1, resource: sampler },
-    { binding: 2, resource: texture.createView() },
+    { binding: 2, resource: texture },
   ],
 });
 
@@ -236,7 +236,7 @@ function render(time: number) {
   // Get the current texture from the canvas context and
   // set it as the texture to render to.
   const canvasTexture = context.getCurrentTexture();
-  renderPassDescriptor.colorAttachments[0].view = canvasTexture.createView();
+  renderPassDescriptor.colorAttachments[0].view = canvasTexture;
 
   // If we don't have a depth texture OR if its size is different
   // from the canvasTexture when make a new depth texture
@@ -254,7 +254,7 @@ function render(time: number) {
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
   }
-  renderPassDescriptor.depthStencilAttachment.view = depthTexture.createView();
+  renderPassDescriptor.depthStencilAttachment.view = depthTexture;
 
   const { size, fixedSize, textured } = settings;
 

--- a/sample/renderBundles/main.ts
+++ b/sample/renderBundles/main.ts
@@ -228,7 +228,7 @@ function createSphereBindGroup(
       },
       {
         binding: 2,
-        resource: texture.createView(),
+        resource: texture,
       },
     ],
   });
@@ -285,7 +285,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -388,9 +388,7 @@ function frame() {
     transformationMatrix.byteOffset,
     transformationMatrix.byteLength
   );
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/resizeCanvas/main.ts
+++ b/sample/resizeCanvas/main.ts
@@ -50,7 +50,6 @@ const pipeline = device.createRenderPipeline({
 });
 
 let renderTarget: GPUTexture | undefined = undefined;
-let renderTargetView: GPUTextureView;
 
 function frame() {
   const currentWidth = canvas.clientWidth * devicePixelRatio;
@@ -62,7 +61,7 @@ function frame() {
   if (
     (currentWidth !== canvas.width ||
       currentHeight !== canvas.height ||
-      !renderTargetView) &&
+      !renderTarget) &&
     currentWidth &&
     currentHeight
   ) {
@@ -83,18 +82,16 @@ function frame() {
       format: presentationFormat,
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
-
-    renderTargetView = renderTarget.createView();
   }
 
-  if (renderTargetView) {
+  if (renderTarget) {
     const commandEncoder = device.createCommandEncoder();
 
     const renderPassDescriptor: GPURenderPassDescriptor = {
       colorAttachments: [
         {
-          view: renderTargetView,
-          resolveTarget: context.getCurrentTexture().createView(),
+          view: renderTarget,
+          resolveTarget: context.getCurrentTexture(),
           clearValue: [0.2, 0.2, 0.2, 1.0],
           loadOp: 'clear',
           storeOp: 'store',

--- a/sample/resizeObserverHDDPI/main.ts
+++ b/sample/resizeObserverHDDPI/main.ts
@@ -118,7 +118,7 @@ function frame() {
   const renderPassDescriptor: GPURenderPassDescriptor = {
     colorAttachments: [
       {
-        view: context.getCurrentTexture().createView(),
+        view: context.getCurrentTexture(),
         clearValue: [0.2, 0.2, 0.2, 1.0],
         loadOp: 'clear',
         storeOp: 'store',

--- a/sample/reversedZ/main.ts
+++ b/sample/reversedZ/main.ts
@@ -330,19 +330,17 @@ const depthTexture = device.createTexture({
   format: depthBufferFormat,
   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
 });
-const depthTextureView = depthTexture.createView();
 
 const defaultDepthTexture = device.createTexture({
   size: [canvas.width, canvas.height],
   format: depthBufferFormat,
   usage: GPUTextureUsage.RENDER_ATTACHMENT,
 });
-const defaultDepthTextureView = defaultDepthTexture.createView();
 
 const depthPrePassDescriptor: GPURenderPassDescriptor = {
   colorAttachments: [],
   depthStencilAttachment: {
-    view: depthTextureView,
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -366,7 +364,7 @@ const drawPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: defaultDepthTextureView,
+    view: defaultDepthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -384,7 +382,7 @@ const drawPassLoadDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: defaultDepthTextureView,
+    view: defaultDepthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -426,7 +424,7 @@ const depthTextureBindGroup = device.createBindGroup({
   entries: [
     {
       binding: 0,
-      resource: depthTextureView,
+      resource: depthTexture,
     },
   ],
 });
@@ -557,7 +555,7 @@ function frame() {
     mvpMatricesData.byteLength
   );
 
-  const attachment = context.getCurrentTexture().createView();
+  const attachment = context.getCurrentTexture();
   const commandEncoder = device.createCommandEncoder();
   if (settings.mode === 'color') {
     for (const m of depthBufferModes) {

--- a/sample/rotatingCube/main.ts
+++ b/sample/rotatingCube/main.ts
@@ -129,7 +129,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -166,9 +166,7 @@ function frame() {
     transformationMatrix.byteOffset,
     transformationMatrix.byteLength
   );
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/samplerParameters/main.ts
+++ b/sample/samplerParameters/main.ts
@@ -202,7 +202,6 @@ const checkerboard = device.createTexture({
   size: [kTextureBaseSize, kTextureBaseSize],
   mipLevelCount: 4,
 });
-const checkerboardView = checkerboard.createView();
 
 const kColorForLevel = [
   [255, 255, 255, 255],
@@ -248,7 +247,7 @@ const showTexturePipeline = device.createRenderPipeline({
 
 const showTextureBG = device.createBindGroup({
   layout: showTexturePipeline.getBindGroupLayout(0),
-  entries: [{ binding: 0, resource: checkerboardView }],
+  entries: [{ binding: 0, resource: checkerboard }],
 });
 
 //
@@ -312,18 +311,16 @@ function frame() {
       { binding: 0, resource: { buffer: bufConfig } },
       { binding: 1, resource: { buffer: bufMatrices } },
       { binding: 2, resource: sampler },
-      { binding: 3, resource: checkerboardView },
+      { binding: 3, resource: checkerboard },
     ],
   });
-
-  const textureView = context.getCurrentTexture().createView();
 
   const commandEncoder = device.createCommandEncoder();
 
   const renderPassDescriptor: GPURenderPassDescriptor = {
     colorAttachments: [
       {
-        view: textureView,
+        view: context.getCurrentTexture(),
         clearValue: [0.2, 0.2, 0.2, 1.0],
         loadOp: 'clear',
         storeOp: 'store',

--- a/sample/shadowMapping/main.ts
+++ b/sample/shadowMapping/main.ts
@@ -63,7 +63,6 @@ const shadowDepthTexture = device.createTexture({
   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
   format: 'depth32float',
 });
-const shadowDepthTextureView = shadowDepthTexture.createView();
 
 // Create some common descriptors used for both the shadow pipeline
 // and the color rendering pipeline.
@@ -203,7 +202,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -251,7 +250,7 @@ const sceneBindGroupForRender = device.createBindGroup({
     },
     {
       binding: 1,
-      resource: shadowDepthTextureView,
+      resource: shadowDepthTexture,
     },
     {
       binding: 2,
@@ -330,7 +329,7 @@ function getCameraViewProjMatrix() {
 const shadowPassDescriptor: GPURenderPassDescriptor = {
   colorAttachments: [],
   depthStencilAttachment: {
-    view: shadowDepthTextureView,
+    view: shadowDepthTexture,
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
     depthStoreOp: 'store',
@@ -347,9 +346,7 @@ function frame() {
     cameraViewProj.byteLength
   );
 
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   {

--- a/sample/skinnedMesh/main.ts
+++ b/sample/skinnedMesh/main.ts
@@ -363,7 +363,7 @@ const gltfRenderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
     depthLoadOp: 'clear',
     depthClearValue: 1.0,
     depthStoreOp: 'store',
@@ -507,13 +507,11 @@ function frame() {
   }
 
   // Difference between these two render passes is just the presence of depthTexture
-  gltfRenderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  gltfRenderPassDescriptor.colorAttachments[0].view =
+    context.getCurrentTexture();
 
-  skinnedGridRenderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  skinnedGridRenderPassDescriptor.colorAttachments[0].view =
+    context.getCurrentTexture();
 
   // Update node matrixes
   for (const scene of whaleScene.scenes) {

--- a/sample/stencilMask/main.ts
+++ b/sample/stencilMask/main.ts
@@ -461,8 +461,8 @@ function drawScene(
 ) {
   const { objectInfos } = scene;
 
-  renderPassDescriptor.colorAttachments[0].view = canvasTexture.createView();
-  renderPassDescriptor.depthStencilAttachment.view = depthTexture.createView();
+  renderPassDescriptor.colorAttachments[0].view = canvasTexture;
+  renderPassDescriptor.depthStencilAttachment.view = depthTexture;
 
   const pass = encoder.beginRenderPass(renderPassDescriptor);
   pass.setPipeline(pipeline);

--- a/sample/textRenderingMsdf/main.ts
+++ b/sample/textRenderingMsdf/main.ts
@@ -248,7 +248,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -314,9 +314,7 @@ function frame() {
     transformationMatrix.byteOffset,
     transformationMatrix.byteLength
   );
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/textRenderingMsdf/msdfText.ts
+++ b/sample/textRenderingMsdf/msdfText.ts
@@ -313,7 +313,7 @@ export class MsdfTextRenderer {
         {
           binding: 0,
           // TODO: Allow multi-page fonts
-          resource: pageTextures[0].createView(),
+          resource: pageTextures[0],
         },
         {
           binding: 1,

--- a/sample/texturedCube/main.ts
+++ b/sample/texturedCube/main.ts
@@ -148,7 +148,7 @@ const uniformBindGroup = device.createBindGroup({
     },
     {
       binding: 2,
-      resource: cubeTexture.createView(),
+      resource: cubeTexture,
     },
   ],
 });
@@ -164,7 +164,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -201,9 +201,7 @@ function frame() {
     transformationMatrix.byteOffset,
     transformationMatrix.byteLength
   );
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/timestampQuery/main.ts
+++ b/sample/timestampQuery/main.ts
@@ -162,7 +162,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -201,9 +201,7 @@ function frame() {
     transformationMatrix.byteOffset,
     transformationMatrix.byteLength
   );
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/transparentCanvas/main.ts
+++ b/sample/transparentCanvas/main.ts
@@ -125,7 +125,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -162,9 +162,7 @@ function frame() {
     transformationMatrix.byteOffset,
     transformationMatrix.byteLength
   );
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/twoCubes/main.ts
+++ b/sample/twoCubes/main.ts
@@ -148,7 +148,7 @@ const renderPassDescriptor: GPURenderPassDescriptor = {
     },
   ],
   depthStencilAttachment: {
-    view: depthTexture.createView(),
+    view: depthTexture,
 
     depthClearValue: 1.0,
     depthLoadOp: 'clear',
@@ -215,9 +215,7 @@ function frame() {
     modelViewProjectionMatrix2.byteLength
   );
 
-  renderPassDescriptor.colorAttachments[0].view = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/videoUploading/main.ts
+++ b/sample/videoUploading/main.ts
@@ -91,12 +91,11 @@ function frame() {
   });
 
   const commandEncoder = device.createCommandEncoder();
-  const textureView = context.getCurrentTexture().createView();
 
   const renderPassDescriptor: GPURenderPassDescriptor = {
     colorAttachments: [
       {
-        view: textureView,
+        view: context.getCurrentTexture(),
         clearValue: [0, 0, 0, 1],
         loadOp: 'clear',
         storeOp: 'store',

--- a/sample/volumeRenderingTexture3D/main.ts
+++ b/sample/volumeRenderingTexture3D/main.ts
@@ -121,7 +121,6 @@ const texture = device.createTexture({
   format: presentationFormat,
   usage: GPUTextureUsage.RENDER_ATTACHMENT,
 });
-const view = texture.createView();
 
 const uniformBufferSize = 4 * 16; // 4x4 matrix
 const uniformBuffer = device.createBuffer({
@@ -253,15 +252,14 @@ function frame() {
   const inverseModelViewProjection =
     getInverseModelViewProjectionMatrix(deltaTime);
   device.queue.writeBuffer(uniformBuffer, 0, inverseModelViewProjection);
-  renderPassDescriptor.colorAttachments[0].view = view;
-  renderPassDescriptor.colorAttachments[0].resolveTarget = context
-    .getCurrentTexture()
-    .createView();
+  renderPassDescriptor.colorAttachments[0].view = texture;
+  renderPassDescriptor.colorAttachments[0].resolveTarget =
+    context.getCurrentTexture();
 
   const commandEncoder = device.createCommandEncoder();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
   if (volumeTexture) {
-    bindGroupDescriptor.entries[2].resource = volumeTexture.createView();
+    bindGroupDescriptor.entries[2].resource = volumeTexture;
     const uniformBindGroup = device.createBindGroup(bindGroupDescriptor);
     passEncoder.setPipeline(pipeline);
     passEncoder.setBindGroup(0, uniformBindGroup);

--- a/sample/wireframe/main.ts
+++ b/sample/wireframe/main.ts
@@ -377,7 +377,7 @@ function render(ts: number) {
   // Get the current texture from the canvas context and
   // set it as the texture to render to.
   const canvasTexture = context.getCurrentTexture();
-  renderPassDescriptor.colorAttachments[0].view = canvasTexture.createView();
+  renderPassDescriptor.colorAttachments[0].view = canvasTexture;
 
   // If we don't have a depth texture OR if its size is different
   // from the canvasTexture when make a new depth texture
@@ -395,7 +395,7 @@ function render(ts: number) {
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
   }
-  renderPassDescriptor.depthStencilAttachment.view = depthTexture.createView();
+  renderPassDescriptor.depthStencilAttachment.view = depthTexture;
 
   const fov = (60 * Math.PI) / 180;
   const aspect = canvas.clientWidth / canvas.clientHeight;

--- a/sample/worker/worker.ts
+++ b/sample/worker/worker.ts
@@ -147,7 +147,7 @@ async function init(canvas) {
       },
     ],
     depthStencilAttachment: {
-      view: depthTexture.createView(),
+      view: depthTexture,
 
       depthClearValue: 1.0,
       depthLoadOp: 'clear',
@@ -189,9 +189,7 @@ async function init(canvas) {
       transformationMatrix.byteOffset,
       transformationMatrix.byteLength
     );
-    renderPassDescriptor.colorAttachments[0].view = context
-      .getCurrentTexture()
-      .createView();
+    renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture();
 
     const commandEncoder = device.createCommandEncoder();
     const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);

--- a/sample/workloadSimulator/index.html
+++ b/sample/workloadSimulator/index.html
@@ -712,7 +712,7 @@ async function render(fromRaf, fromPostMessage) {
           entries: [
             { binding: 0, resource: { buffer: uniformBuffer } },
             { binding: 1, resource: sampler },
-            { binding: 2, resource: texture.createView() },
+            { binding: 2, resource: texture },
           ],
         });
       } catch(e) {
@@ -729,7 +729,7 @@ async function render(fromRaf, fromPostMessage) {
       return;
     }
     try {
-      const canvasView = canvasContext.getCurrentTexture().createView();
+      const canvasTexture = canvasContext.getCurrentTexture();
 
       device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([position[0] / size * 2 - 1, 1 - position[1] * 2 / size]));
       let buffer = null;
@@ -797,14 +797,14 @@ async function render(fromRaf, fromPostMessage) {
 
       // Record command buffer.
       const commandEncoder = device.createCommandEncoder();
-      let renderAttachment = canvasView;
+      let renderAttachment = canvasTexture;
       if (multisampling.checked) {
-        renderAttachment = multisampleRenderAttachment.createView();
+        renderAttachment = multisampleRenderAttachment;
       }
       const passEncoder = commandEncoder.beginRenderPass({
         colorAttachments: [ {
           view: renderAttachment,
-          resolveTarget: multisampling.checked ? canvasView : undefined,
+          resolveTarget: multisampling.checked ? canvasTexture : undefined,
           loadOp: 'clear',
           clearValue: [1, 1, 1, 1],
           storeOp: multisampling.checked ? 'discard' : 'store',


### PR DESCRIPTION
Spec PR: https://github.com/gpuweb/gpuweb/pull/5228

Note that support is available only in Chrome Canary[ for now](https://chromiumdash.appspot.com/commit/d172c015da875206fc746701314cbfce77efc3db).