### PR TITLE
Don't use Compatibility Mode till Chrome bug is not fixed

### DIFF
--- a/sample/videoUploading/main.ts
+++ b/sample/videoUploading/main.ts
@@ -3,9 +3,7 @@ import fullscreenTexturedQuadWGSL from '../../shaders/fullscreenTexturedQuad.wgs
 import sampleExternalTextureWGSL from '../../shaders/sampleExternalTexture.frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
-const adapter = await navigator.gpu?.requestAdapter({
-  featureLevel: 'compatibility',
-});
+const adapter = await navigator.gpu?.requestAdapter();
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 


### PR DESCRIPTION
This PR removes the use of featureLevel: 'compatibility' in the requestAdapter() call for the videoUploading sample.
## Why
Using compatibility mode currently triggers a validation error on Chrome with Metal backend (macOS) when importing external video textures.

Fixes #522 

Verified and working

<img width="1823" height="1099" alt="465770920-4e768737-a422-47a7-8d96-5f6b825a8aa5" src="https://github.com/user-attachments/assets/6d3cbf24-7ef8-439d-aba9-e08b13eb354e" />
