### PR TITLE
Add Search Functionality to Filter Sample List

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,76 +1,81 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>WebGPU Samples</title>
-    <meta
-      name="description"
-      content="The WebGPU Samples are a set of samples demonstrating the use of the WebGPU API."
-    />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
 
-    <link
-      href="https://fonts.googleapis.com/css?family=Inconsolata&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      rel="icon"
-      type="image/x-icon"
-      href="favicon.ico"
-    />
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>WebGPU Samples</title>
+  <meta name="description" content="The WebGPU Samples are a set of samples demonstrating the use of the WebGPU API." />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
-    <link href="css/styles.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Inconsolata&display=swap" rel="stylesheet" />
+  <link rel="icon" type="image/x-icon" href="favicon.ico" />
 
-  </head>
-  <script defer type="module" src="main.js"></script>
-  <body>
-    <div class="wrapper">
-      <nav class="panel container">
-        <h1>
-          <a href="./">WebGPU Samples</a>
-        </h1>
-        <input type="checkbox" id="menuToggle">
-        <label class="expand" for="menuToggle"></label>
-        <div class="panelContents">
-          <a href="https://github.com/webgpu/webgpu-samples">
-              Github
-          </a>
+  <link href="css/styles.css" rel="stylesheet">
+
+</head>
+<script defer type="module" src="main.js"></script>
+
+<body>
+  <div class="wrapper">
+    <nav class="panel container">
+      <h1>
+        <a href="./">WebGPU Samples</a>
+      </h1>
+      <input type="checkbox" id="menuToggle">
+      <label class="expand" for="menuToggle"></label>
+      <div class="panelContents">
+        <search>
           <hr>
-          <div id="samplelist"></div>
-        </div>
-      </nav>
+          <label>
+            <svg width="24px" height="24px" viewBox="0 0 1024 1024" class="icon" version="1.1"
+              xmlns="http://www.w3.org/2000/svg">
+              <title>Search</title>
+              <path
+                d="M448 768A320 320 0 1 0 448 128a320 320 0 0 0 0 640z m297.344-76.992l214.592 214.592-54.336 54.336-214.592-214.592a384 384 0 1 1 54.336-54.336z"
+                fill="currentColor" />
+            </svg>
+            <input type="search" name="search">
+          </label>
+          <hr>
+        </search>
 
-      <main>
-        <div id="intro">
-          <p>
-            The WebGPU Samples are a set of samples and demos demonstrating the use
-            of the <a href="//webgpu.dev">WebGPU API</a>. Please see the current
-            implementation status and how to run WebGPU in your browser at
-            <a href="//webgpu.io">webgpu.io</a>.
-          </p>
+        <a href="https://github.com/webgpu/webgpu-samples">
+          Github
+        </a>
+        <hr>
+        <div id="samplelist"></div>
+      </div>
+    </nav>
+
+    <main>
+      <div id="intro">
+        <p>
+          The WebGPU Samples are a set of samples and demos demonstrating the use
+          of the <a href="//webgpu.dev">WebGPU API</a>. Please see the current
+          implementation status and how to run WebGPU in your browser at
+          <a href="//webgpu.io">webgpu.io</a>.
+        </p>
+      </div>
+      <div id="sample" style="display: none;">
+        <div class="sampleInfo">
+          <h1 id="title"></h1>
+          <a id="src" target="_blank" rel="noreferrer" href="">View source!</a>
+          &mdash; <a id="standalone" target="_blank" rel="noreferrer" href="">View as standalone webpage</a>
+          <p id="description"></p>
         </div>
-        <div id="sample" style="display: none;">
-          <div class="sampleInfo">
-            <h1 id="title"></h1>
-            <a id="src" target="_blank" rel="noreferrer" href="">View source!</a>
-            &mdash; <a id="standalone" target="_blank" rel="noreferrer" href="">View as standalone webpage</a>
-            <p id="description"></p>
-          </div>
-          <div class="sampleContainer"></div>
+        <div class="sampleContainer"></div>
+      </div>
+      <nav id="code" class="sourceFileNav">
+        <div class="sourceLR" id="sourceL">&lt;</div>
+        <div id="sourceTabs" class="sourceFileScrollContainer">
+          <ul id="codeTabs"></ul>
         </div>
-        <nav id="code" class="sourceFileNav">
-          <div class="sourceLR" id="sourceL">&lt;</div>
-          <div id="sourceTabs" class="sourceFileScrollContainer">
-            <ul id="codeTabs"></ul>
-          </div>
-          <div class="sourceLR" id="sourceR">&gt;</div>
-        </nav>
-        <div id="sources"></div>
-      </main>
-    </div>
-  </body>
+        <div class="sourceLR" id="sourceR">&gt;</div>
+      </nav>
+      <div id="sources"></div>
+    </main>
+  </div>
+</body>
+
 </html>

--- a/public/css/MainLayout.css
+++ b/public/css/MainLayout.css
@@ -64,6 +64,48 @@ main {
   overflow: auto;
 }
 
+search {
+  inline-size: 100%;
+  margin-block-end: 20px;
+
+  &>hr {
+    border-color: var(--tooltip-border);
+    margin-block: 0;
+  }
+
+  &>label {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 10px;
+    inline-size: 100%;
+    block-size: 50px;
+
+    &:has(input:focus)>svg {
+      display: none;
+    }
+
+    &>svg {
+      margin-inline-start: 10px;
+    }
+
+    &>input {
+      opacity: 0;
+      border: none;
+      block-size: 100%;
+      flex: 1;
+      padding-inline: 20px;
+      background-color: var(--panel-background);
+      font-size: 1rem;
+
+      &:is(:focus) {
+        opacity: 1;
+      }
+    }
+  }
+
+}
+
 @media only screen and (max-width: 768px) {
   .wrapper {
     flex-direction: column;
@@ -73,12 +115,12 @@ main {
     overflow: visible;
   }
 
-  #menuToggle ~ .panelContents {
+  #menuToggle~.panelContents {
     max-height: 0;
     overflow: hidden;
   }
 
-  #menuToggle:checked ~ .panelContents {
+  #menuToggle:checked~.panelContents {
     max-height: 2000px;
   }
 
@@ -99,4 +141,3 @@ main {
   }
 
 }
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -273,47 +273,96 @@ function setSampleIFrameURL(e: PointerEvent, sampleInfo: SampleInfo) {
   setSampleIFrame(sampleInfo);
 }
 
+const searchInput = document.querySelector(
+  'input[type="search"]'
+) as HTMLInputElement;
+
+let debounceTimer: number | undefined;
+
+searchInput.addEventListener('input', () => {
+  clearTimeout(debounceTimer);
+  debounceTimer = window.setTimeout(() => {
+    const q = searchInput.value.trim();
+    const url = new URL(window.location.href);
+
+    if (q) {
+      url.searchParams.set('q', q);
+    } else {
+      url.searchParams.delete('q');
+    }
+
+    // Do NOT touch 'sample' param — we preserve it
+    history.replaceState(null, '', url.toString());
+
+    // Re-render the list
+    sampleListElem.innerHTML = '';
+    samplesByKey.clear();
+    renderSampleList();
+  }, 200); // debounce delay
+});
+
 // Samples are looked up by `?sample=key` so this is a map
 // from those keys to each sample.
 const samplesByKey = new Map<string, SampleInfo>();
 
-// Generate the list of samples
-for (const { title, description, samples } of pageCategories) {
-  for (const [key, sampleInfo] of Object.entries(samples)) {
-    samplesByKey.set(key, sampleInfo);
-  }
+renderSampleList();
 
-  sampleListElem.appendChild(
-    el('ul', { className: 'exampleList' }, [
-      el('div', {}, [
-        el('div', { className: 'sampleCategory' }, [
-          el('h3', {
-            style: { 'margin-top': '5px' },
-            textContent: title,
-            dataset: { tooltip: description },
-          }),
-        ]),
-        ...Object.entries(samples).map(([key, sampleInfo]) =>
-          el('li', {}, [
-            el('a', {
-              href: sampleInfo.external
-                ? sampleInfo.external.url
-                : sampleInfo.filename,
-              ...(!sampleInfo.openInNewTab && {
-                onClick: (e: PointerEvent) => {
-                  setSampleIFrameURL(e, sampleInfo);
-                },
-              }),
-              textContent: `${sampleInfo.tocName || key}${
-                sampleInfo.openInNewTab ? ' ↗️' : ''
-              }`,
-              ...(sampleInfo.openInNewTab && { target: '_blank' }),
+// Generate the list of samples
+function renderSampleList() {
+  const url = new URL(window.location.href);
+  const q = url.searchParams.get('q')?.toLowerCase().trim() || '';
+
+  sampleListElem.innerHTML = '';
+  samplesByKey.clear();
+
+  for (const { title, description, samples } of pageCategories) {
+    const filteredSamples = Object.entries(samples).filter(([, sample]) => {
+      if (!q) return true;
+      const name = sample.name?.toLowerCase() || '';
+      const tocName = sample.tocName?.toLowerCase() || '';
+      const titleMatch = title.toLowerCase().includes(q);
+      return name.includes(q) || tocName.includes(q) || titleMatch;
+    });
+
+    // Skip categories with no matches
+    if (filteredSamples.length === 0) continue;
+
+    for (const [key, sampleInfo] of filteredSamples) {
+      samplesByKey.set(key, sampleInfo);
+    }
+
+    sampleListElem.appendChild(
+      el('ul', { className: 'exampleList' }, [
+        el('div', {}, [
+          el('div', { className: 'sampleCategory' }, [
+            el('h3', {
+              style: { 'margin-top': '5px' },
+              textContent: title,
+              dataset: { tooltip: description },
             }),
-          ])
-        ),
-      ]),
-    ])
-  );
+          ]),
+          ...filteredSamples.map(([key, sampleInfo]) =>
+            el('li', {}, [
+              el('a', {
+                href: sampleInfo.external
+                  ? sampleInfo.external.url
+                  : sampleInfo.filename,
+                ...(!sampleInfo.openInNewTab && {
+                  onClick: (e: PointerEvent) => {
+                    setSampleIFrameURL(e, sampleInfo);
+                  },
+                }),
+                textContent: `${sampleInfo.tocName || key}${
+                  sampleInfo.openInNewTab ? ' ↗️' : ''
+                }`,
+                ...(sampleInfo.openInNewTab && { target: '_blank' }),
+              }),
+            ])
+          ),
+        ]),
+      ])
+    );
+  }
 }
 
 sourceLElem.addEventListener('click', () => switchToRelativeTab(-1).click());


### PR DESCRIPTION
## Summary

This PR introduces a search bar to the WebGPU samples page, enabling users to filter the list of available samples in real time based on their query. 

New <input type="search"> added to the page.
	•	Input value synced with the ?q= query parameter in the URL.
	•	Filtering logic applies on both initial load and live input changes.
	•	Filters against:
	•	Sample title
	•	tocName
	•	Category title

Fixes #379 
	