### PR TITLE
Revert "Don't use Compatibility Mode till Chrome bug is fixed (#523)"

### DIFF
--- a/sample/videoUploading/main.ts
+++ b/sample/videoUploading/main.ts
@@ -3,7 +3,9 @@ import fullscreenTexturedQuadWGSL from '../../shaders/fullscreenTexturedQuad.wgs
 import sampleExternalTextureWGSL from '../../shaders/sampleExternalTexture.frag.wgsl';
 import { quitIfWebGPUNotAvailable } from '../util';
 
-const adapter = await navigator.gpu?.requestAdapter();
+const adapter = await navigator.gpu?.requestAdapter({
+  featureLevel: 'compatibility',
+});
 const device = await adapter?.requestDevice();
 quitIfWebGPUNotAvailable(adapter, device);
 


### PR DESCRIPTION
This reverts commit b28ddf74c34cd9b6d0db29d1974022554caca5f1.

Bug was [fixed in Dawn](https://dawn-review.googlesource.com/c/dawn/+/252698) and rolled into [Chrome 1487302](http://crrev.com/1487302), shipping in today's Canary.
