### PR TITLE
Prevent Bind Group Error with Zero Triangles

### DIFF
--- a/sample/animometer/main.ts
+++ b/sample/animometer/main.ts
@@ -168,7 +168,7 @@ function configure() {
   const alignedUniformFloats =
     alignedUniformBytes / Float32Array.BYTES_PER_ELEMENT;
   const uniformBuffer = device.createBuffer({
-    size: numTriangles * alignedUniformBytes + Float32Array.BYTES_PER_ELEMENT,
+    size: Math.max(numTriangles, 1) * alignedUniformBytes + Float32Array.BYTES_PER_ELEMENT,
     usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
   });
   const uniformBufferData = new Float32Array(


### PR DESCRIPTION
Thank you very much for this great sample! This quick fix allocates at least one triangle’s space in the uniform buffer, avoiding the “Uncaptured error: GPUDevice.createBindGroup: entrySize == 0 or entrySize(24) + entryOffset(0) > buffer size(4) or layoutBinding->minBindingSize(20) > entrySize(24)” when numTriangles is 0 on iPadOS 18.5 (with feature flag enabled). It is quite easy to set to zero, so the error is easily triggered, and I guess users might want to set it to zero (initially, I thought of setting the minimum to one; however, this also provides some statistics, just in case). Thank you very much in advance! If any changes would make this PR more suitable, please let me know, and I can adjust.