### PR TITLE
Fix for toneMapping mode check

### DIFF
--- a/sample/particles/main.ts
+++ b/sample/particles/main.ts
@@ -355,7 +355,7 @@ function getHdrFolderName() {
   }
   if (
     simulationParams.toneMappingMode === 'extended' &&
-    context.getConfiguration().toneMapping.mode !== 'extended'
+    context.getConfiguration().toneMapping?.mode !== 'extended'
   ) {
     return "HDR settings ⚠️ Browser doesn't support HDR canvas";
   }


### PR DESCRIPTION
The spec says `toneMapping` won't exist if this isn't supported.