### PR TITLE
Fall back when particles HDR canvas format is unsupported

### DIFF
--- a/sample/particles/main.ts
+++ b/sample/particles/main.ts
@@ -3,7 +3,7 @@ import { GUI } from 'dat.gui';
 
 import particleWGSL from './particle.wgsl';
 import probabilityMapWGSL from './probabilityMap.wgsl';
-import { quitIfWebGPUNotAvailableOrMissingFeatures } from '../util';
+import { fail, quitIfWebGPUNotAvailableOrMissingFeatures } from '../util';
 
 const numParticles = 50000;
 const particlePositionOffset = 0;
@@ -28,14 +28,48 @@ const context = canvas.getContext('webgpu');
 const devicePixelRatio = window.devicePixelRatio;
 canvas.width = canvas.clientWidth * devicePixelRatio;
 canvas.height = canvas.clientHeight * devicePixelRatio;
-const presentationFormat = 'rgba16float';
+const hdrPresentationFormat: GPUTextureFormat = 'rgba16float';
+let presentationFormat: GPUTextureFormat = hdrPresentationFormat;
+let hasHDRCanvasFormat = true;
 
-function configureContext() {
+try {
   context.configure({
     device,
     format: presentationFormat,
-    toneMapping: { mode: simulationParams.toneMappingMode },
+    toneMapping: { mode: 'standard' },
   });
+} catch (error) {
+  hasHDRCanvasFormat = false;
+  presentationFormat = navigator.gpu.getPreferredCanvasFormat();
+
+  try {
+    context.configure({
+      device,
+      format: presentationFormat,
+    });
+  } catch (fallbackError) {
+    fail(
+      `Unable to configure the WebGPU canvas. The HDR format '${hdrPresentationFormat}' is not supported by this browser, and configuring the preferred canvas format '${presentationFormat}' also failed.\n\n${fallbackError}`
+    );
+  }
+
+  console.warn(
+    `Canvas texture format '${hdrPresentationFormat}' is not supported by this browser. Falling back to '${presentationFormat}'.`,
+    error
+  );
+}
+
+function configureContext() {
+  const configuration: GPUCanvasConfiguration = {
+    device,
+    format: presentationFormat,
+  };
+
+  if (hasHDRCanvasFormat) {
+    configuration.toneMapping = { mode: simulationParams.toneMappingMode };
+  }
+
+  context.configure(configuration);
   hdrFolder.name = getHdrFolderName();
 }
 
@@ -335,6 +369,9 @@ const hdrMediaQuery = window.matchMedia('(dynamic-range: high)');
 function getHdrFolderName() {
   if (!hdrMediaQuery.matches) {
     return "HDR settings ⚠️ Display isn't compatible";
+  }
+  if (!hasHDRCanvasFormat) {
+    return "HDR settings ⚠️ Browser doesn't support HDR canvas";
   }
   if (!('getConfiguration' in GPUCanvasContext.prototype)) {
     return 'HDR settings';

--- a/sample/util.ts
+++ b/sample/util.ts
@@ -181,7 +181,7 @@ export function quitIfWebGPUNotAvailableOrMissingFeatures(
 }
 
 /** Fail by showing a console error, and dialog box if possible. */
-const fail = (() => {
+export const fail = (() => {
   type ErrorOutput = { show(msg: string): void };
 
   function createErrorOutput() {


### PR DESCRIPTION
## Summary

Fixes #564.

The particles sample currently configures its canvas as `rgba16float` unconditionally. Firefox reports that format as unsupported and throws from `GPUCanvasContext.configure()`, which sends the page through the global "uncaught exception, please report a bug" dialog.

This keeps `rgba16float` as the preferred HDR path, but catches unsupported canvas configuration and falls back to the browser's preferred canvas format. When the fallback path is active, the sample omits HDR-only `toneMapping` settings and marks the HDR settings UI as browser-unsupported instead of stopping the page.

## Changes

- Try the `rgba16float` canvas configuration before creating the render pipeline.
- Fall back to the browser's preferred canvas format if HDR canvas configuration throws.
- Skip canvas `toneMapping` settings while using the fallback format.
- Show the browser-unsupported HDR state in the existing HDR settings UI.
- Reuse the shared sample error dialog if both HDR and fallback canvas configuration fail.

## Verification

- `npx eslint sample/particles/main.ts sample/util.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Manual Firefox smoke: Firefox rejected `rgba16float`, logged a fallback to `bgra8unorm`, continued rendering the particles sample, and the `brightnessFactor` control remained interactive without an uncaught-exception dialog.
