### PR TITLE
Add external Vision Transformer sample

### DIFF
--- a/sample/visionTransformer/meta.ts
+++ b/sample/visionTransformer/meta.ts
@@ -1,0 +1,10 @@
+export default {
+  name: 'Vision Transformer',
+  description: `Runs DeiT-Tiny Vision Transformer inference in WebGPU compute shaders and visualizes attention maps as interactive heatmap overlays.`,
+  filename: __DIRNAME__,
+  external: {
+    url: 'https://lyonsno.github.io/webgpu-vit-attention/',
+    sourceURL: 'https://github.com/lyonsno/webgpu-vit-attention',
+  },
+  sources: [],
+};

--- a/src/samples.ts
+++ b/src/samples.ts
@@ -43,6 +43,7 @@ import timestampQuery from '../sample/timestampQuery/meta';
 import transparentCanvas from '../sample/transparentCanvas/meta';
 import twoCubes from '../sample/twoCubes/meta';
 import videoUploading from '../sample/videoUploading/meta';
+import visionTransformer from '../sample/visionTransformer/meta';
 import volumeRenderingTexture3D from '../sample/volumeRenderingTexture3D/meta';
 import wireframe from '../sample/wireframe/meta';
 import worker from '../sample/worker/meta';
@@ -173,6 +174,7 @@ export const pageCategories: PageCategory[] = [
       marchingCubes,
       alphaToCoverageEmulator,
       particleLife,
+      visionTransformer,
     },
   },
 


### PR DESCRIPTION
Adds an external sample that runs DeiT-Tiny Vision Transformer inference in WebGPU compute shaders and visualizes attention maps as interactive heatmap overlays.

This follows the external sample path suggested in #569, and is related to #350.

External sample: https://lyonsno.github.io/webgpu-vit-attention/
Repository: https://github.com/lyonsno/webgpu-vit-attention

I'm happy to make any changes that may be needed. Please let me know whether this sample is appropriate for inclusion.